### PR TITLE
chore: bump version to 1.7.1 for PyPI release

### DIFF
--- a/oilpriceapi/version.py
+++ b/oilpriceapi/version.py
@@ -5,6 +5,6 @@ Single source of truth for the SDK version string.
 Used in __init__.py, client.py, and async_client.py.
 """
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 SDK_VERSION = __version__
 SDK_NAME = "oilpriceapi-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oilpriceapi"
-version = "1.7.0"
+version = "1.7.1"
 description = "Official Python SDK for OilPriceAPI - Real-time and historical oil prices"
 authors = [
     {name = "OilPriceAPI", email = "support@oilpriceapi.com"}


### PR DESCRIPTION
Bumps pyproject + version.py to 1.7.1 so package version matches the release tag and unsticks PyPI from 1.6.2. Follows #29.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK version to 1.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->