### PR TITLE
feat: async WebSocket streaming client

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ print(f"Test status: {result['status']}")
 - ✅ **Data Quality** - Real-time quality monitoring and reporting
 - ✅ **Data Sources** - Connector management with health checks and logging
 - ✅ **Async Support** - High-performance async client
+- ✅ **WebSocket Streaming** - Real-time price stream via ActionCable (Professional+)
 - ✅ **Smart Caching** - Reduce API calls automatically
 - ✅ **Rate Limit Handling** - Automatic retries with backoff
 - ✅ **Error Handling** - Comprehensive exception classes
@@ -530,6 +531,70 @@ async def get_prices():
 # Run async function
 prices = asyncio.run(get_prices())
 ```
+
+## 📡 Real-Time WebSocket Streaming (New in v1.8.0)
+
+Stream live oil and energy prices over WebSocket instead of polling. Streaming
+is a **Professional / Reservoir Mastery** feature and is exposed through the
+async client via `client.stream`.
+
+Install the optional `stream` extra:
+
+```bash
+pip install 'oilpriceapi[stream]'
+```
+
+```python
+import asyncio
+from oilpriceapi import AsyncOilPriceAPI
+
+async def watch_prices():
+    async with AsyncOilPriceAPI() as client:
+        # Opens an ActionCable subscription to EnergyPricesChannel at /cable.
+        async with client.stream.prices(commodities=["BRENT_CRUDE_USD"]) as stream:
+            async for update in stream:
+                if update.type == "price_update":
+                    brent = update.price_update.prices.oil.brent
+                    print(f"Brent: ${brent.original_price} "
+                          f"({brent.original_currency}) @ {update.price_update.timestamp}")
+                elif update.type == "rig_count_update":
+                    rc = update.rig_count_update.rig_count
+                    print(f"Rig count [{rc.region}]: {rc.count}")
+
+asyncio.run(watch_prices())
+```
+
+Each `update` is a typed `StreamUpdate`:
+
+| `update.type`      | Populated model           | Contents                                  |
+| ------------------ | ------------------------- | ----------------------------------------- |
+| `welcome`          | `update.price_update`     | Initial price snapshot on subscribe       |
+| `price_update`     | `update.price_update`     | Latest Brent/WTI + UK/US/EU natural gas   |
+| `rig_count_update` | `update.rig_count_update` | Drilling rig count update (premium tiers) |
+
+`update.raw` always holds the decoded payload dict for forward compatibility.
+
+**Features:**
+
+- ActionCable JSON subprotocol (welcome → subscribe → confirm → messages, pings handled)
+- Token auth via query param + `Authorization` header
+- Auto-reconnect with exponential backoff + jitter (`auto_reconnect`, `max_reconnect_attempts`)
+- Clean teardown (unsubscribe + close) on context-manager exit
+- Pydantic-typed update models
+
+```python
+# Tune reconnection behavior:
+stream = client.stream.prices(
+    commodities=["BRENT_CRUDE_USD", "WTI_USD"],
+    auto_reconnect=True,
+    max_reconnect_attempts=10,
+    reconnect_base_delay=1.0,
+    reconnect_max_delay=30.0,
+)
+```
+
+> WebSocket streaming requires a Professional+ plan. Subscriptions from
+> lower tiers are rejected during the ActionCable handshake.
 
 ## 🧪 Testing
 

--- a/oilpriceapi/__init__.py
+++ b/oilpriceapi/__init__.py
@@ -29,6 +29,13 @@ from oilpriceapi.models import (
     PriceAlert,
     WebhookTestResponse,
 )
+from oilpriceapi.streaming import (
+    PriceStream,
+    PriceUpdate,
+    RigCountUpdate,
+    StreamingNotInstalledError,
+    StreamUpdate,
+)
 
 __all__ = [
     "OilPriceAPI",
@@ -47,6 +54,11 @@ __all__ = [
     "PriceAlert",
     "WebhookTestResponse",
     "DataConnectorPrice",
+    "PriceStream",
+    "StreamUpdate",
+    "PriceUpdate",
+    "RigCountUpdate",
+    "StreamingNotInstalledError",
 ]
 
 from oilpriceapi.resources.webhooks import WebhooksResource

--- a/oilpriceapi/async_client.py
+++ b/oilpriceapi/async_client.py
@@ -149,6 +149,11 @@ class AsyncOilPriceAPI:
         self.webhooks = AsyncWebhooksResource(self)
         self.data_sources = AsyncDataSourcesResource(self)
 
+        # Real-time WebSocket streaming namespace (requires the [stream] extra).
+        # Lazily imports `websockets` only when a stream is actually opened.
+        from .streaming import AsyncStreamNamespace
+        self.stream = AsyncStreamNamespace(self)
+
         # Initialize telemetry (opt-in, disabled by default)
         from .telemetry import Telemetry
         self._telemetry = Telemetry(enabled=enable_telemetry)

--- a/oilpriceapi/streaming/__init__.py
+++ b/oilpriceapi/streaming/__init__.py
@@ -1,0 +1,43 @@
+"""
+Real-time WebSocket streaming for OilPriceAPI.
+
+Exposes an async streaming client over the Rails ActionCable ``/cable``
+endpoint (``EnergyPricesChannel``). Available via ``AsyncOilPriceAPI.stream``.
+
+Requires the optional ``[stream]`` extra::
+
+    pip install 'oilpriceapi[stream]'
+"""
+from __future__ import annotations
+
+from .client import (
+    CHANNEL_NAME,
+    AsyncStreamNamespace,
+    PriceStream,
+    StreamingNotInstalledError,
+)
+from .models import (
+    NaturalGasPrices,
+    NormalizedPrice,
+    OilPrices,
+    PriceBlock,
+    PriceUpdate,
+    RigCount,
+    RigCountUpdate,
+    StreamUpdate,
+)
+
+__all__ = [
+    "AsyncStreamNamespace",
+    "PriceStream",
+    "StreamingNotInstalledError",
+    "CHANNEL_NAME",
+    "StreamUpdate",
+    "PriceUpdate",
+    "RigCountUpdate",
+    "PriceBlock",
+    "OilPrices",
+    "NaturalGasPrices",
+    "NormalizedPrice",
+    "RigCount",
+]

--- a/oilpriceapi/streaming/client.py
+++ b/oilpriceapi/streaming/client.py
@@ -1,0 +1,331 @@
+"""
+Async WebSocket streaming client for OilPriceAPI.
+
+Implements the Rails ActionCable JSON subprotocol against the ``/cable``
+endpoint and exposes an ergonomic async-iterator API:
+
+    >>> async with client.stream.prices(commodities=["BRENT_CRUDE_USD"]) as stream:
+    ...     async for update in stream:
+    ...         print(update.type, update.raw)
+
+ActionCable handshake (as implemented by the OilPriceAPI server):
+
+1. Client connects to ``wss://api.oilpriceapi.com/cable`` (auth via ``?token=``
+   query param or ``Authorization: Token <key>`` header).
+2. Server sends ``{"type": "welcome"}``.
+3. Client sends a ``subscribe`` command whose ``identifier`` is a JSON string
+   ``{"channel": "EnergyPricesChannel", "api_key": "<key>"}``.
+4. Server replies ``{"type": "confirm_subscription", "identifier": ...}``.
+5. Broadcasts arrive as ``{"identifier": ..., "message": {...}}``.
+6. Server periodically sends ``{"type": "ping"}`` keepalives (ignored).
+
+Requires the optional ``[stream]`` extra (``pip install oilpriceapi[stream]``).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Type
+
+from .models import StreamUpdate
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from ..async_client import AsyncOilPriceAPI
+
+logger = logging.getLogger(__name__)
+
+# ActionCable channel name as defined server-side (EnergyPricesChannel).
+CHANNEL_NAME = "EnergyPricesChannel"
+
+
+class StreamingNotInstalledError(ImportError):
+    """Raised when the optional ``websockets`` dependency is missing."""
+
+
+def _import_websockets() -> Any:
+    """Import the ``websockets`` library, raising a friendly error if absent."""
+    try:
+        import websockets  # noqa: PLC0415
+
+        return websockets
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise StreamingNotInstalledError(
+            "WebSocket streaming requires the 'websockets' package. "
+            "Install it with: pip install 'oilpriceapi[stream]'"
+        ) from exc
+
+
+class PriceStream:
+    """An async-iterable handle over a single ActionCable subscription.
+
+    Connects lazily on ``__aenter__`` (or first iteration), performs the
+    ActionCable handshake, and yields :class:`StreamUpdate` objects. On
+    transient disconnects it reconnects with exponential backoff + jitter,
+    transparently re-subscribing, up to ``max_reconnect_attempts``.
+    """
+
+    def __init__(
+        self,
+        *,
+        cable_url: str,
+        api_key: str,
+        channel: str = CHANNEL_NAME,
+        params: Optional[Dict[str, Any]] = None,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int = 10,
+        reconnect_base_delay: float = 1.0,
+        reconnect_max_delay: float = 30.0,
+        ping_interval: Optional[float] = None,
+        open_timeout: float = 10.0,
+    ) -> None:
+        self._cable_url = cable_url
+        self._api_key = api_key
+        self._channel = channel
+        self._params = params or {}
+        self._auto_reconnect = auto_reconnect
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._reconnect_base_delay = reconnect_base_delay
+        self._reconnect_max_delay = reconnect_max_delay
+        self._ping_interval = ping_interval
+        self._open_timeout = open_timeout
+
+        self._ws: Any = None
+        self._closed = False
+        self._subscribed = False
+
+    # -- identifier --------------------------------------------------------
+
+    @property
+    def identifier(self) -> str:
+        """The ActionCable subscription identifier (a JSON string)."""
+        ident: Dict[str, Any] = {"channel": self._channel, "api_key": self._api_key}
+        ident.update(self._params)
+        # Sort keys for a stable identifier (ActionCable matches on exact string).
+        return json.dumps(ident, sort_keys=True)
+
+    # -- connection lifecycle ---------------------------------------------
+
+    async def connect(self) -> None:
+        """Open the WebSocket and complete the ActionCable handshake."""
+        websockets = _import_websockets()
+        # Auth via query param is the most portable across proxies; the server
+        # also accepts the Authorization header (connection.rb find_verified_user).
+        sep = "&" if "?" in self._cable_url else "?"
+        url = f"{self._cable_url}{sep}token={self._api_key}"
+        headers = {"Authorization": f"Token {self._api_key}"}
+
+        self._ws = await websockets.connect(
+            url,
+            additional_headers=headers,
+            ping_interval=self._ping_interval,
+            open_timeout=self._open_timeout,
+        )
+        await self._await_welcome()
+        await self._subscribe()
+
+    async def _await_welcome(self) -> None:
+        """Wait for the ActionCable ``welcome`` frame before subscribing."""
+        while True:
+            raw = await self._ws.recv()
+            data = json.loads(raw)
+            msg_type = data.get("type")
+            if msg_type == "welcome":
+                return
+            if msg_type == "disconnect":
+                raise ConnectionError(
+                    f"Server refused connection: {data.get('reason', 'unknown')}"
+                )
+            # Ignore stray pings while waiting for welcome.
+
+    async def _subscribe(self) -> None:
+        """Send the subscribe command and await ``confirm_subscription``."""
+        await self._ws.send(
+            json.dumps({"command": "subscribe", "identifier": self.identifier})
+        )
+        while True:
+            raw = await self._ws.recv()
+            data = json.loads(raw)
+            msg_type = data.get("type")
+            if msg_type == "confirm_subscription":
+                self._subscribed = True
+                return
+            if msg_type == "reject_subscription":
+                raise ConnectionError(
+                    "Subscription rejected — check your plan tier and API key "
+                    "(WebSocket streaming requires Reservoir Mastery)."
+                )
+            # Ignore pings / pre-confirmation noise.
+
+    async def close(self) -> None:
+        """Unsubscribe and close the underlying WebSocket."""
+        self._closed = True
+        if self._ws is not None:
+            try:
+                if self._subscribed:
+                    await self._ws.send(
+                        json.dumps({"command": "unsubscribe", "identifier": self.identifier})
+                    )
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                logger.debug("Failed to send unsubscribe on close", exc_info=True)
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                logger.debug("Failed to close websocket cleanly", exc_info=True)
+            finally:
+                self._ws = None
+                self._subscribed = False
+
+    # -- async context manager --------------------------------------------
+
+    async def __aenter__(self) -> "PriceStream":
+        await self.connect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self.close()
+
+    # -- iteration ---------------------------------------------------------
+
+    def __aiter__(self) -> AsyncIterator[StreamUpdate]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[StreamUpdate]:
+        websockets = _import_websockets()
+        connection_closed = websockets.exceptions.ConnectionClosed
+        connection_closed_ok = websockets.exceptions.ConnectionClosedOK
+
+        if self._ws is None and not self._closed:
+            await self.connect()
+
+        attempts = 0
+        while not self._closed:
+            try:
+                raw = await self._ws.recv()
+            except connection_closed_ok:
+                # Clean server-side close — end iteration, do not reconnect.
+                break
+            except connection_closed:
+                if not self._auto_reconnect or self._closed:
+                    break
+                attempts += 1
+                if attempts > self._max_reconnect_attempts:
+                    raise ConnectionError(
+                        f"Stream lost after {self._max_reconnect_attempts} reconnect attempts"
+                    )
+                await self._backoff(attempts)
+                await self._reconnect()
+                continue
+
+            attempts = 0  # reset backoff after any successful receive
+            data = json.loads(raw)
+            update = self._dispatch(data)
+            if update is not None:
+                yield update
+
+    def _dispatch(self, data: Dict[str, Any]) -> Optional[StreamUpdate]:
+        """Translate a raw ActionCable frame into a StreamUpdate (or None)."""
+        msg_type = data.get("type")
+        # Protocol control frames carry a top-level "type"; ignore them.
+        if msg_type in ("ping", "welcome", "confirm_subscription", "reject_subscription"):
+            return None
+        if msg_type == "disconnect":
+            logger.warning("ActionCable disconnect frame: %s", data.get("reason"))
+            return None
+
+        message = data.get("message")
+        if not isinstance(message, dict):
+            return None
+        return StreamUpdate.from_message(message)
+
+    # -- reconnect ---------------------------------------------------------
+
+    async def _backoff(self, attempt: int) -> None:
+        delay = min(
+            self._reconnect_base_delay * (2 ** (attempt - 1)),
+            self._reconnect_max_delay,
+        )
+        delay += random.uniform(0, delay * 0.25)  # noqa: S311 - jitter, not crypto
+        logger.info("Reconnecting stream in %.2fs (attempt %d)", delay, attempt)
+        await asyncio.sleep(delay)
+
+    async def _reconnect(self) -> None:
+        self._subscribed = False
+        self._ws = None
+        await self.connect()
+
+
+class AsyncStreamNamespace:
+    """``client.stream`` namespace exposing streaming factory methods."""
+
+    def __init__(self, client: "AsyncOilPriceAPI") -> None:
+        self._client = client
+
+    def _cable_url(self) -> str:
+        base = self._client.base_url
+        # https -> wss, http -> ws; append /cable mount point.
+        if base.startswith("https://"):
+            ws_base = "wss://" + base[len("https://") :]
+        elif base.startswith("http://"):
+            ws_base = "ws://" + base[len("http://") :]
+        else:
+            ws_base = base
+        return ws_base.rstrip("/") + "/cable"
+
+    def prices(
+        self,
+        commodities: Optional[List[str]] = None,
+        *,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int = 10,
+        reconnect_base_delay: float = 1.0,
+        reconnect_max_delay: float = 30.0,
+        open_timeout: float = 10.0,
+    ) -> PriceStream:
+        """Open a real-time price stream over ``EnergyPricesChannel``.
+
+        Args:
+            commodities: Optional list of commodity codes to tag the
+                subscription with (sent as a ``commodities`` identifier
+                param). The server currently broadcasts the full price block;
+                filter client-side via ``update.price_update`` if desired.
+            auto_reconnect: Reconnect with backoff on transient drops.
+            max_reconnect_attempts: Give up after this many failures.
+            reconnect_base_delay: Initial backoff delay (seconds).
+            reconnect_max_delay: Maximum backoff delay (seconds).
+            open_timeout: Connection open timeout (seconds).
+
+        Returns:
+            A :class:`PriceStream` async context manager / iterator.
+
+        Example:
+            >>> async with client.stream.prices(["BRENT_CRUDE_USD"]) as stream:
+            ...     async for update in stream:
+            ...         if update.type == "price_update":
+            ...             print(update.price_update.prices)
+        """
+        params: Dict[str, Any] = {}
+        if commodities:
+            params["commodities"] = list(commodities)
+
+        api_key = self._client.api_key
+        if not api_key:
+            raise ValueError("An API key is required to open a stream.")
+
+        return PriceStream(
+            cable_url=self._cable_url(),
+            api_key=api_key,
+            params=params,
+            auto_reconnect=auto_reconnect,
+            max_reconnect_attempts=max_reconnect_attempts,
+            reconnect_base_delay=reconnect_base_delay,
+            reconnect_max_delay=reconnect_max_delay,
+            open_timeout=open_timeout,
+        )

--- a/oilpriceapi/streaming/models.py
+++ b/oilpriceapi/streaming/models.py
@@ -1,0 +1,170 @@
+"""
+Pydantic models for WebSocket streaming payloads.
+
+These mirror the broadcast shapes emitted by the OilPriceAPI ActionCable
+``EnergyPricesChannel`` (see the API ``BroadcastEnergyPricesJob`` and channel
+``send_initial_prices``). Three message types are streamed:
+
+* ``welcome``           - initial snapshot sent on subscription
+* ``price_update``      - debounced broadcast of the latest spot prices
+* ``rig_count_update``  - drilling-intelligence rig count update
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _parse_ts(v: Any) -> Any:
+    """Parse an ISO-8601 timestamp string into a ``datetime``."""
+    if isinstance(v, str):
+        try:
+            return datetime.fromisoformat(v.replace("Z", "+00:00"))
+        except ValueError:
+            from dateutil import parser  # type: ignore[import-untyped]
+
+            return parser.parse(v)
+    return v
+
+
+class NormalizedPrice(BaseModel):
+    """A single normalized price entry inside a price block."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    normalized_price: Optional[float] = Field(
+        default=None, description="Price normalized to USD/MMBtu"
+    )
+    original_price: Optional[float] = Field(
+        default=None, description="Price in its original unit/currency"
+    )
+    original_unit: Optional[str] = Field(default=None, description="Original unit of measure")
+    original_currency: Optional[str] = Field(default=None, description="Original currency code")
+    timestamp: Optional[datetime] = Field(default=None, description="Price timestamp")
+    change_24h: Optional[float] = Field(default=None, description="Absolute 24h change")
+    change_24h_percent: Optional[float] = Field(default=None, description="Percentage 24h change")
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _ts(cls, v: Any) -> Any:
+        return _parse_ts(v)
+
+
+class OilPrices(BaseModel):
+    """Oil price block (Brent + WTI)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    brent: Optional[NormalizedPrice] = None
+    wti: Optional[NormalizedPrice] = None
+
+
+class NaturalGasPrices(BaseModel):
+    """Natural gas price block (UK / US / EU)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    uk: Optional[NormalizedPrice] = None
+    us: Optional[NormalizedPrice] = None
+    eu: Optional[NormalizedPrice] = None
+
+
+class PriceBlock(BaseModel):
+    """Container of all normalized price groups in a broadcast."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    oil: Optional[OilPrices] = None
+    natural_gas: Optional[NaturalGasPrices] = None
+
+
+class PriceUpdate(BaseModel):
+    """A ``price_update`` (or ``welcome``) broadcast message.
+
+    The ``welcome`` snapshot shares the same shape but carries ``type``
+    ``"welcome"`` and an optional ``error`` field when initial data could not
+    be assembled server-side.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(default="price_update", description="Message type")
+    timestamp: Optional[datetime] = Field(default=None, description="Broadcast timestamp")
+    base_currency: Optional[str] = Field(default=None, description="Normalization base currency")
+    base_unit: Optional[str] = Field(default=None, description="Normalization base unit")
+    prices: Optional[PriceBlock] = Field(default=None, description="Normalized price groups")
+    error: Optional[str] = Field(default=None, description="Error message for degraded snapshots")
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _ts(cls, v: Any) -> Any:
+        return _parse_ts(v)
+
+
+class RigCount(BaseModel):
+    """Rig count detail inside a ``rig_count_update`` message."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    code: Optional[str] = Field(default=None, description="Drilling code, e.g. US_RIG_COUNT")
+    region: Optional[str] = Field(default=None, description="Human-readable region name")
+    count: Optional[float] = Field(default=None, description="Rig count value")
+    source: Optional[str] = Field(default=None, description="Data source")
+    updated_at: Optional[datetime] = Field(default=None, description="Last update timestamp")
+
+    @field_validator("updated_at", mode="before")
+    @classmethod
+    def _ts(cls, v: Any) -> Any:
+        return _parse_ts(v)
+
+
+class RigCountUpdate(BaseModel):
+    """A ``rig_count_update`` broadcast message."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(default="rig_count_update", description="Message type")
+    timestamp: Optional[datetime] = Field(default=None, description="Broadcast timestamp")
+    rig_count: Optional[RigCount] = Field(default=None, description="Rig count detail")
+
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _ts(cls, v: Any) -> Any:
+        return _parse_ts(v)
+
+
+class StreamUpdate(BaseModel):
+    """Wrapper yielded by the stream for any broadcast payload.
+
+    ``raw`` always holds the decoded ``message`` dict. ``price_update`` /
+    ``rig_count_update`` are populated when the payload matches a known type,
+    so consumers can branch on ``update.type`` and read the typed model.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(description="Broadcast message type")
+    raw: Dict[str, Any] = Field(description="Raw decoded message payload")
+    price_update: Optional[PriceUpdate] = Field(default=None)
+    rig_count_update: Optional[RigCountUpdate] = Field(default=None)
+
+    @classmethod
+    def from_message(cls, message: Dict[str, Any]) -> "StreamUpdate":
+        """Build a typed update from a raw ActionCable ``message`` payload."""
+        msg_type = str(message.get("type", "unknown"))
+        price_update: Optional[PriceUpdate] = None
+        rig_count_update: Optional[RigCountUpdate] = None
+
+        if msg_type in ("price_update", "welcome"):
+            price_update = PriceUpdate.model_validate(message)
+        elif msg_type == "rig_count_update":
+            rig_count_update = RigCountUpdate.model_validate(message)
+
+        return cls(
+            type=msg_type,
+            raw=message,
+            price_update=price_update,
+            rig_count_update=rig_count_update,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ pandas = [
     "numpy>=1.20.0",
 ]
 async = []
+stream = [
+    "websockets>=11.0",
+]
 cache = [
     "redis>=4.5.0",
     "cachetools>=5.3.0",
@@ -60,7 +63,7 @@ cli = [
     "rich>=13.0.0",
 ]
 all = [
-    "oilpriceapi[pandas,async,cache,cli]",
+    "oilpriceapi[pandas,async,stream,cache,cli]",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -73,6 +76,9 @@ dev = [
     "mypy>=1.0.0,<3",
     "ruff>=0.0.261",
     "pre-commit>=3.0.0",
+    # WebSocket streaming extra — needed so the streaming unit tests can
+    # import `websockets` in CI.
+    "websockets>=11.0",
 ]
 
 [project.urls]

--- a/tests/unit/test_streaming.py
+++ b/tests/unit/test_streaming.py
@@ -1,0 +1,365 @@
+"""
+Unit tests for the async WebSocket streaming client.
+
+The ``websockets`` transport is fully mocked — these tests never touch the
+network. They cover: the ActionCable handshake (welcome -> subscribe ->
+confirm_subscription), message dispatch (price_update / rig_count_update /
+ping / control-frame filtering), typed-model parsing, reconnect-with-backoff,
+and clean teardown (unsubscribe + close).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from oilpriceapi import AsyncOilPriceAPI
+from oilpriceapi.streaming.client import PriceStream
+from oilpriceapi.streaming.models import StreamUpdate
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+
+class FakeWebSocket:
+    """A scripted fake of a ``websockets`` connection.
+
+    ``incoming`` is a list of frames the server "sends". String/dict frames
+    are delivered via ``recv``; an item of the sentinel ``CLOSE`` raises a
+    ConnectionClosed to simulate a drop; ``STOP`` ends the stream cleanly.
+    """
+
+    CLOSE = object()
+
+    def __init__(self, incoming: List[Any]) -> None:
+        self._incoming = list(incoming)
+        self.sent: List[Dict[str, Any]] = []
+        self.closed = False
+
+    async def recv(self) -> str:
+        if not self._incoming:
+            # No more frames — emulate a graceful server close (no reconnect).
+            import websockets
+
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+        item = self._incoming.pop(0)
+        if item is self.CLOSE:
+            # Abrupt drop — should trigger auto-reconnect.
+            import websockets
+
+            raise websockets.exceptions.ConnectionClosed(None, None)
+        if isinstance(item, dict):
+            return json.dumps(item)
+        return item
+
+    async def send(self, message: str) -> None:
+        self.sent.append(json.loads(message))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeConnector:
+    """Stands in for ``websockets.connect`` — hands out queued sockets."""
+
+    def __init__(self, sockets: List[FakeWebSocket]) -> None:
+        self._sockets = list(sockets)
+        self.connect_calls: List[Dict[str, Any]] = []
+
+    async def __call__(self, url: str, **kwargs: Any) -> FakeWebSocket:
+        self.connect_calls.append({"url": url, **kwargs})
+        return self._sockets.pop(0)
+
+
+def _patch_connect(monkeypatch: pytest.MonkeyPatch, connector: FakeConnector) -> None:
+    import websockets
+
+    monkeypatch.setattr(websockets, "connect", connector)
+
+
+def _welcome() -> Dict[str, Any]:
+    return {"type": "welcome"}
+
+
+def _confirm(ident: str) -> Dict[str, Any]:
+    return {"type": "confirm_subscription", "identifier": ident}
+
+
+def _broadcast(message: Dict[str, Any], ident: str = "x") -> Dict[str, Any]:
+    return {"identifier": ident, "message": message}
+
+
+PRICE_UPDATE_MSG = {
+    "type": "price_update",
+    "timestamp": "2026-06-21T10:00:00Z",
+    "base_currency": "USD",
+    "base_unit": "MMBtu",
+    "prices": {
+        "oil": {
+            "brent": {
+                "normalized_price": 12.3,
+                "original_price": 75.5,
+                "original_unit": "barrel_oil",
+                "original_currency": "USD",
+                "timestamp": "2026-06-21T10:00:00Z",
+            },
+            "wti": None,
+        },
+        "natural_gas": {"uk": None, "us": None, "eu": None},
+    },
+}
+
+RIG_UPDATE_MSG = {
+    "type": "rig_count_update",
+    "timestamp": "2026-06-21T10:05:00Z",
+    "rig_count": {
+        "code": "US_RIG_COUNT",
+        "region": "United States",
+        "count": 480,
+        "source": "Baker Hughes",
+        "updated_at": "2026-06-20T16:00:00Z",
+    },
+}
+
+
+# --------------------------------------------------------------------------
+# Model tests
+# --------------------------------------------------------------------------
+
+def test_stream_update_from_price_message():
+    update = StreamUpdate.from_message(PRICE_UPDATE_MSG)
+    assert update.type == "price_update"
+    assert update.price_update is not None
+    assert update.rig_count_update is None
+    assert update.price_update.prices.oil.brent.original_price == 75.5
+    assert update.raw == PRICE_UPDATE_MSG
+
+
+def test_stream_update_from_rig_message():
+    update = StreamUpdate.from_message(RIG_UPDATE_MSG)
+    assert update.type == "rig_count_update"
+    assert update.rig_count_update is not None
+    assert update.rig_count_update.rig_count.code == "US_RIG_COUNT"
+    assert update.rig_count_update.rig_count.count == 480
+
+
+def test_stream_update_welcome_parses_as_price_update():
+    msg = {"type": "welcome", "error": "Initial data temporarily unavailable"}
+    update = StreamUpdate.from_message(msg)
+    assert update.type == "welcome"
+    assert update.price_update is not None
+    assert update.price_update.error == "Initial data temporarily unavailable"
+
+
+# --------------------------------------------------------------------------
+# Handshake tests
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_handshake_sends_subscribe(monkeypatch, api_key):
+    ident_holder: Dict[str, str] = {}
+
+    ws = FakeWebSocket([])
+    # Build incoming after we know the identifier? Simpler: drive manually.
+    stream = PriceStream(
+        cable_url="wss://api.oilpriceapi.com/cable",
+        api_key=api_key,
+        params={"commodities": ["BRENT_CRUDE_USD"]},
+    )
+    ident = stream.identifier
+    ws._incoming = [_welcome(), _confirm(ident)]  # type: ignore[attr-defined]
+    connector = FakeConnector([ws])
+    _patch_connect(monkeypatch, connector)
+
+    await stream.connect()
+    try:
+        # Subscribe command was sent with the correct ActionCable identifier.
+        assert ws.sent[0]["command"] == "subscribe"
+        sub_ident = json.loads(ws.sent[0]["identifier"])
+        assert sub_ident["channel"] == "EnergyPricesChannel"
+        assert sub_ident["api_key"] == api_key
+        assert sub_ident["commodities"] == ["BRENT_CRUDE_USD"]
+        # Token passed via query param for portable auth.
+        assert "token=" in connector.connect_calls[0]["url"]
+        assert (
+            connector.connect_calls[0]["additional_headers"]["Authorization"]
+            == f"Token {api_key}"
+        )
+        assert stream._subscribed is True
+        ident_holder["ident"] = ident
+    finally:
+        await stream.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_subscription_raises(monkeypatch, api_key):
+    stream = PriceStream(cable_url="wss://h/cable", api_key=api_key)
+    ws = FakeWebSocket([_welcome(), {"type": "reject_subscription"}])
+    _patch_connect(monkeypatch, FakeConnector([ws]))
+
+    with pytest.raises(ConnectionError, match="Subscription rejected"):
+        await stream.connect()
+
+
+# --------------------------------------------------------------------------
+# Dispatch / iteration tests
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_iteration_dispatches_messages(monkeypatch, api_key):
+    stream = PriceStream(cable_url="wss://h/cable", api_key=api_key)
+    ident = stream.identifier
+    ws = FakeWebSocket(
+        [
+            _welcome(),
+            _confirm(ident),
+            {"type": "ping", "message": 1234},  # ignored
+            _broadcast(PRICE_UPDATE_MSG, ident),
+            _broadcast(RIG_UPDATE_MSG, ident),
+        ]
+    )
+    _patch_connect(monkeypatch, FakeConnector([ws]))
+
+    updates: List[StreamUpdate] = []
+    async with stream as s:
+        async for update in s:
+            updates.append(update)
+
+    types = [u.type for u in updates]
+    assert types == ["price_update", "rig_count_update"]
+    assert updates[0].price_update.base_unit == "MMBtu"
+    assert updates[1].rig_count_update.rig_count.region == "United States"
+
+
+@pytest.mark.asyncio
+async def test_control_frames_are_filtered(monkeypatch, api_key):
+    stream = PriceStream(cable_url="wss://h/cable", api_key=api_key)
+    ident = stream.identifier
+    ws = FakeWebSocket(
+        [
+            _welcome(),
+            _confirm(ident),
+            {"type": "ping"},
+            {"type": "confirm_subscription", "identifier": ident},
+            _broadcast(PRICE_UPDATE_MSG, ident),
+        ]
+    )
+    _patch_connect(monkeypatch, FakeConnector([ws]))
+
+    updates = [u async for u in stream]
+    assert len(updates) == 1
+    assert updates[0].type == "price_update"
+    await stream.close()
+
+
+# --------------------------------------------------------------------------
+# Reconnect tests
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_reconnect_on_drop(monkeypatch, api_key):
+    stream = PriceStream(
+        cable_url="wss://h/cable",
+        api_key=api_key,
+        reconnect_base_delay=0.0,
+        reconnect_max_delay=0.0,
+    )
+    ident = stream.identifier
+
+    ws1 = FakeWebSocket([_welcome(), _confirm(ident), _broadcast(PRICE_UPDATE_MSG, ident), FakeWebSocket.CLOSE])
+    ws2 = FakeWebSocket([_welcome(), _confirm(ident), _broadcast(RIG_UPDATE_MSG, ident)])
+    connector = FakeConnector([ws1, ws2])
+    _patch_connect(monkeypatch, connector)
+
+    # Avoid real sleeping during backoff.
+    async def _no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    updates = [u async for u in stream]
+    assert [u.type for u in updates] == ["price_update", "rig_count_update"]
+    # Reconnected => connect called twice, re-subscribed on the new socket.
+    assert len(connector.connect_calls) == 2
+    assert ws2.sent[0]["command"] == "subscribe"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_gives_up_after_max_attempts(monkeypatch, api_key):
+    stream = PriceStream(
+        cable_url="wss://h/cable",
+        api_key=api_key,
+        max_reconnect_attempts=1,
+        reconnect_base_delay=0.0,
+    )
+    ident = stream.identifier
+    # Each socket drops immediately after handshake; second drop exceeds max=1.
+    ws1 = FakeWebSocket([_welcome(), _confirm(ident), FakeWebSocket.CLOSE])
+    ws2 = FakeWebSocket([_welcome(), _confirm(ident), FakeWebSocket.CLOSE])
+    _patch_connect(monkeypatch, FakeConnector([ws1, ws2]))
+
+    async def _no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    with pytest.raises(ConnectionError, match="reconnect attempts"):
+        async for _ in stream:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_auto_reconnect_disabled_ends_cleanly(monkeypatch, api_key):
+    stream = PriceStream(
+        cable_url="wss://h/cable", api_key=api_key, auto_reconnect=False
+    )
+    ident = stream.identifier
+    ws = FakeWebSocket([_welcome(), _confirm(ident), _broadcast(PRICE_UPDATE_MSG, ident), FakeWebSocket.CLOSE])
+    _patch_connect(monkeypatch, FakeConnector([ws]))
+
+    updates = [u async for u in stream]
+    assert [u.type for u in updates] == ["price_update"]
+
+
+# --------------------------------------------------------------------------
+# Teardown tests
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_close_sends_unsubscribe(monkeypatch, api_key):
+    stream = PriceStream(cable_url="wss://h/cable", api_key=api_key)
+    ident = stream.identifier
+    ws = FakeWebSocket([_welcome(), _confirm(ident)])
+    _patch_connect(monkeypatch, FakeConnector([ws]))
+
+    await stream.connect()
+    await stream.close()
+
+    assert ws.closed is True
+    assert ws.sent[-1]["command"] == "unsubscribe"
+    assert stream._ws is None
+
+
+# --------------------------------------------------------------------------
+# Namespace wiring tests
+# --------------------------------------------------------------------------
+
+def test_client_exposes_stream_namespace(api_key):
+    client = AsyncOilPriceAPI(api_key=api_key)
+    assert hasattr(client, "stream")
+    stream = client.stream.prices(commodities=["WTI_USD"])
+    assert isinstance(stream, PriceStream)
+    ident = json.loads(stream.identifier)
+    assert ident["channel"] == "EnergyPricesChannel"
+    assert ident["commodities"] == ["WTI_USD"]
+
+
+def test_cable_url_derivation(api_key):
+    client = AsyncOilPriceAPI(api_key=api_key, base_url="https://api.oilpriceapi.com")
+    assert client.stream._cable_url() == "wss://api.oilpriceapi.com/cable"
+
+    client2 = AsyncOilPriceAPI(api_key=api_key, base_url="http://localhost:5000")
+    assert client2.stream._cable_url() == "ws://localhost:5000/cable"


### PR DESCRIPTION
## Summary

Adds a real-time **async WebSocket streaming client** to the Python SDK, exposing the OilPriceAPI ActionCable stream (`/cable`, `EnergyPricesChannel`) — a Professional+ feature no SDK previously surfaced. Available via `client.stream` on the async client.

## Channel / protocol (confirmed from source)

Source of truth: `oilpriceapi-api/app/channels/` + `oilpriceapi-docs/docs/websocket/`.

- **Endpoint**: `wss://api.oilpriceapi.com/cable` (mounted at `/cable` in `config/routes.rb`)
- **Channel**: `EnergyPricesChannel`
- **Auth** (`application_cable/connection.rb#find_verified_user`): API token via `?token=` query param **or** `Authorization: Token <key>` header → resolves `ApiKey.active.find_by_token`; subscription further requires `current_user.can_access_websocket?` (Reservoir Mastery / Professional+), else `reject`.
- **Subprotocol** (ActionCable JSON): server sends `{"type":"welcome"}` → client sends `{"command":"subscribe","identifier":"{\"channel\":\"EnergyPricesChannel\",\"api_key\":\"...\"}"}` → server `{"type":"confirm_subscription"}` → broadcasts arrive as `{"identifier":...,"message":{...}}`; `{"type":"ping"}` keepalives ignored.
- **Message shapes** (from `BroadcastEnergyPricesJob` + channel `send_initial_prices`):
  - `welcome` — initial snapshot (same shape as price_update; may carry `error`)
  - `price_update` — `prices.oil.{brent,wti}` + `prices.natural_gas.{uk,us,eu}`, each a normalized price block
  - `rig_count_update` — `rig_count.{code,region,count,source,updated_at}`

## Streaming API

```python
async with client.stream.prices(commodities=["BRENT_CRUDE_USD"]) as stream:
    async for update in stream:
        if update.type == "price_update":
            print(update.price_update.prices.oil.brent.original_price)
        elif update.type == "rig_count_update":
            print(update.rig_count_update.rig_count.count)
```

- Async context manager + async iterator yielding typed `StreamUpdate` (Pydantic), with `.price_update` / `.rig_count_update` accessors and `.raw` passthrough.
- Auto-reconnect with exponential backoff + jitter (configurable `auto_reconnect`, `max_reconnect_attempts`, `reconnect_base_delay/max_delay`); clean server close (`ConnectionClosedOK`) ends iteration without reconnect.
- Clean teardown: unsubscribe + close on exit.
- New optional `[stream]` extra (`websockets>=11`); lazily imported so the base SDK is unaffected. Wired into `all` and `dev`.
- Exported from `oilpriceapi.__init__`: `PriceStream`, `StreamUpdate`, `PriceUpdate`, `RigCountUpdate`, `StreamingNotInstalledError`.

## Test results (exact CI commands)

- `ruff check oilpriceapi/` → **All checks passed**
- `mypy oilpriceapi/ --ignore-missing-imports` → **Success: no issues found in 39 source files** (new modules fully annotated, strict-clean)
- `pytest tests/ --ignore=tests/integration --ignore=tests/contract -m 'not slow' --cov=oilpriceapi` → **240 passed, 9 skipped**, coverage **55.9% (≥ 50%)**

13 new unit tests with a fully mocked websocket transport (no network): handshake/subscribe, rejected subscription, message dispatch, control-frame filtering, reconnect-on-drop, give-up after max attempts, auto-reconnect disabled, unsubscribe-on-close, namespace wiring, cable-URL derivation. New module coverage: `streaming/client.py` 92.6%, `streaming/models.py` 95.4%.

No version bump / tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)