### PR TITLE
chore: release 1.8.0

### DIFF
--- a/oilpriceapi/version.py
+++ b/oilpriceapi/version.py
@@ -5,6 +5,6 @@ Single source of truth for the SDK version string.
 Used in __init__.py, client.py, and async_client.py.
 """
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"
 SDK_VERSION = __version__
 SDK_NAME = "oilpriceapi-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oilpriceapi"
-version = "1.7.1"
+version = "1.8.0"
 description = "Official Python SDK for OilPriceAPI - Real-time and historical oil prices"
 authors = [
     {name = "OilPriceAPI", email = "support@oilpriceapi.com"}


### PR DESCRIPTION
Version bump: async WebSocket streaming + analytics/webhooks/data_sources param fixes + mypy typing-debt paydown + live demo contract tests. Cutting v1.8.0 after merge publishes via PyPI trusted publishing.