### PR TITLE
feat: market-brief + agent-subscription methods (sync+async, v1.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,75 @@ result = client.data_sources.test("123")
 print(f"Test status: {result['status']}")
 ```
 
+### Market Brief (New in v1.9.0)
+
+Get a multi-commodity structured summary (latest price, 24h change, and a
+1-month forecast per commodity) in a single request. Pass `narrative=True` to
+also receive a natural-language summary.
+
+```python
+brief = client.market_brief(["BRENT_CRUDE_USD", "WTI_USD"], narrative=True)
+
+print(f"As of: {brief.as_of}")
+for c in brief.commodities:
+    print(f"{c.code}: ${c.price} ({c.change_24h_pct:+.2f}% 24h)")
+    if c.forecast_1m:
+        print(f"  1m forecast: {c.forecast_1m.point} "
+              f"[{c.forecast_1m.low}–{c.forecast_1m.high}] ({c.forecast_1m.confidence})")
+
+if brief.narrative:
+    print(brief.narrative)
+```
+
+### Agent Subscriptions (New in v1.9.0)
+
+Create persistent "watches" that periodically evaluate commodities and emit
+events your agent can poll for. The `interval` accepts a friendly string
+(`"5m"`, `"1h"`, `"daily"`) or raw seconds.
+
+```python
+# Create a subscription
+sub = client.subscriptions.create(
+    codes=["BRENT_CRUDE_USD"],
+    interval="5m",            # also accepts "1h", "daily", or 300
+    name="Brent watch",
+)
+print(sub.id, sub.interval_seconds)  # -> 300
+
+# List subscriptions
+for s in client.subscriptions.list():
+    print(s.name, s.codes, s.status)
+
+# Poll for events using a cursor
+page = client.subscriptions.events(since=0)
+for event in page:
+    print(event.type, event.code)
+# Persist page.cursor and pass it as `since` on the next poll
+next_page = client.subscriptions.events(since=page.cursor)
+
+# Delete a subscription
+client.subscriptions.delete(sub.id)
+```
+
+Attribution headers are sent automatically (`X-OPA-Source` defaults to
+`sdk-python`). MCP tools can override them:
+
+```python
+client.subscriptions.create(
+    ["WTI_USD"], interval="1h", source="mcp", tool="claude-desktop"
+)
+```
+
+All of the above is mirrored on the async client:
+
+```python
+async with AsyncOilPriceAPI() as client:
+    brief = await client.market_brief(["BRENT_CRUDE_USD"])
+    sub = await client.subscriptions.create(["WTI_USD"], interval="daily")
+    page = await client.subscriptions.events(since=0)
+    await client.subscriptions.delete(sub.id)
+```
+
 ## 📊 Features
 
 - ✅ **Simple API** - Intuitive methods for all endpoints
@@ -444,6 +513,8 @@ print(f"Test status: {result['status']}")
 - ✅ **Energy Intelligence** - EIA data, OPEC production, drilling productivity
 - ✅ **Data Quality** - Real-time quality monitoring and reporting
 - ✅ **Data Sources** - Connector management with health checks and logging
+- ✅ **Market Brief** - Multi-commodity structured + narrative summary in one call 🧠
+- ✅ **Agent Subscriptions** - Persistent watches + event polling for AI agents 🤖
 - ✅ **Async Support** - High-performance async client
 - ✅ **WebSocket Streaming** - Real-time price stream via ActionCable (Professional+)
 - ✅ **Smart Caching** - Reduce API calls automatically

--- a/oilpriceapi/__init__.py
+++ b/oilpriceapi/__init__.py
@@ -28,9 +28,15 @@ from oilpriceapi.models import (
     DieselPrice,
     DieselStation,
     DieselStationsResponse,
+    MarketBrief,
+    MarketBriefCommodity,
+    MarketBriefForecast,
     PriceAlert,
+    Subscription,
+    SubscriptionEvent,
     WebhookTestResponse,
 )
+from oilpriceapi.resources.subscriptions import SubscriptionEventsPage
 from oilpriceapi.streaming import (
     PriceStream,
     PriceUpdate,
@@ -56,6 +62,12 @@ __all__ = [
     "PriceAlert",
     "WebhookTestResponse",
     "DataConnectorPrice",
+    "MarketBrief",
+    "MarketBriefCommodity",
+    "MarketBriefForecast",
+    "Subscription",
+    "SubscriptionEvent",
+    "SubscriptionEventsPage",
     "PriceStream",
     "StreamUpdate",
     "PriceUpdate",

--- a/oilpriceapi/_subscriptions_common.py
+++ b/oilpriceapi/_subscriptions_common.py
@@ -1,0 +1,111 @@
+"""
+Shared helpers for the agent-subscriptions + market-brief features (#3245).
+
+Keeps the sync and async resources behaving identically: friendly interval
+parsing, attribution header construction, and response unwrapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+# Default attribution source stamped on subscriptions created via this SDK.
+DEFAULT_SOURCE = "sdk-python"
+
+# Friendly interval aliases → seconds. Anything else falls through to the
+# numeric parser below (e.g. "30s", "15m", "2h", "1d", or a raw int).
+_INTERVAL_ALIASES: Dict[str, int] = {
+    "1m": 60,
+    "5m": 300,
+    "10m": 600,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "hourly": 3600,
+    "6h": 21600,
+    "12h": 43200,
+    "1d": 86400,
+    "daily": 86400,
+}
+
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def normalize_interval(interval: Union[str, int]) -> int:
+    """Convert a friendly interval into ``interval_seconds``.
+
+    Accepts an int (returned as-is), a named alias ("5m", "1h", "daily"), or a
+    ``<number><unit>`` string where unit is one of s/m/h/d (e.g. "30s", "2h").
+
+    Raises:
+        ValueError: If the interval cannot be parsed or is non-positive.
+    """
+    if isinstance(interval, bool):  # bool is an int subclass; reject explicitly
+        raise ValueError(f"Invalid interval: {interval!r}")
+    if isinstance(interval, int):
+        if interval <= 0:
+            raise ValueError(f"interval_seconds must be positive, got {interval}")
+        return interval
+
+    if not isinstance(interval, str):
+        raise ValueError(f"Invalid interval type: {type(interval).__name__}")
+
+    key = interval.strip().lower()
+    if key in _INTERVAL_ALIASES:
+        return _INTERVAL_ALIASES[key]
+
+    # Plain integer string e.g. "300".
+    if key.isdigit():
+        seconds = int(key)
+        if seconds <= 0:
+            raise ValueError(f"interval_seconds must be positive, got {seconds}")
+        return seconds
+
+    # <number><unit> form e.g. "45s", "2h".
+    if len(key) >= 2 and key[-1] in _UNIT_SECONDS and key[:-1].isdigit():
+        seconds = int(key[:-1]) * _UNIT_SECONDS[key[-1]]
+        if seconds <= 0:
+            raise ValueError(f"interval_seconds must be positive, got {seconds}")
+        return seconds
+
+    raise ValueError(
+        f"Unrecognized interval {interval!r}. Use seconds (int), a named alias "
+        f"('5m', '1h', 'daily'), or '<n><unit>' where unit is s/m/h/d."
+    )
+
+
+def build_attribution_headers(
+    source: Optional[str] = None,
+    tool: Optional[str] = None,
+) -> Dict[str, str]:
+    """Build the X-OPA-Source / X-OPA-Tool attribution headers.
+
+    Defaults ``source`` to ``sdk-python``; omits the tool header when unset.
+    """
+    headers: Dict[str, str] = {"X-OPA-Source": source or DEFAULT_SOURCE}
+    if tool:
+        headers["X-OPA-Tool"] = tool
+    return headers
+
+
+def build_create_body(
+    codes: List[str],
+    interval: Union[str, int],
+    name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the POST /v1/subscriptions request body from friendly args."""
+    body: Dict[str, Any] = {
+        "codes": list(codes),
+        "interval_seconds": normalize_interval(interval),
+    }
+    if name is not None:
+        body["name"] = name
+    return body
+
+
+def unwrap_data(response: Any) -> Dict[str, Any]:
+    """Return the ``data`` object from a ``{status, data}`` envelope."""
+    if isinstance(response, dict) and "data" in response:
+        data = response["data"]
+        return data if isinstance(data, dict) else {}
+    return response if isinstance(response, dict) else {}

--- a/oilpriceapi/async_client.py
+++ b/oilpriceapi/async_client.py
@@ -17,6 +17,7 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+from ._subscriptions_common import unwrap_data
 from .async_resources import (
     AsyncAlertsResource,
     AsyncAnalyticsResource,
@@ -31,6 +32,7 @@ from .async_resources import (
     AsyncFuturesResource,
     AsyncRigCountsResource,
     AsyncStorageResource,
+    AsyncSubscriptionsResource,
     AsyncWebhooksResource,
 )
 from .exceptions import (
@@ -42,7 +44,7 @@ from .exceptions import (
     ServerError,
     TimeoutError,
 )
-from .models import HistoricalPrice, HistoricalResponse, Price
+from .models import HistoricalPrice, HistoricalResponse, MarketBrief, Price
 from .retry import RetryStrategy
 
 
@@ -148,6 +150,8 @@ class AsyncOilPriceAPI:
         self.ei = AsyncEnergyIntelligenceResource(self)
         self.webhooks = AsyncWebhooksResource(self)
         self.data_sources = AsyncDataSourcesResource(self)
+        # Agent watch subscriptions + event polling (#3245 Phase 2).
+        self.subscriptions = AsyncSubscriptionsResource(self)
 
         # Real-time WebSocket streaming namespace (requires the [stream] extra).
         # Lazily imports `websockets` only when a stream is actually opened.
@@ -341,6 +345,34 @@ class AsyncOilPriceAPI:
                 except (ValueError, TypeError):
                     pass
         return None
+
+    async def market_brief(
+        self,
+        codes: List[str],
+        narrative: bool = False,
+    ) -> MarketBrief:
+        """Get a multi-commodity structured (+ optional narrative) market brief.
+
+        Composes existing price/forecast data for the given commodity codes into
+        a single structured summary (#3245 Phase 1a). Counts as one request.
+
+        Args:
+            codes: Commodity codes to include (e.g. ["BRENT_CRUDE_USD", "WTI"]).
+            narrative: When True, request a natural-language narrative as well.
+
+        Returns:
+            A MarketBrief model.
+        """
+        params: Dict[str, Any] = {"codes": ",".join(codes)}
+        if narrative:
+            params["narrative"] = "true"
+
+        response = await self.request(
+            method="GET",
+            path="/v1/market-brief",
+            params=params,
+        )
+        return MarketBrief(**unwrap_data(response))
 
     async def close(self):
         """Close the HTTP client and flush telemetry."""

--- a/oilpriceapi/async_resources.py
+++ b/oilpriceapi/async_resources.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ._subscriptions_common import (
+    build_attribution_headers,
+    build_create_body,
+    unwrap_data,
+)
 from .exceptions import ValidationError
-from .models import DieselPrice, DieselStationsResponse, PriceAlert
+from .models import DieselPrice, DieselStationsResponse, PriceAlert, Subscription, SubscriptionEvent
 from .resource_validators import VALID_OPERATORS, format_date
 from .resources._futures_slug import normalize_futures_slug
+from .resources.subscriptions import SubscriptionEventsPage
 
 
 class AsyncDieselResource:
@@ -1403,3 +1409,83 @@ class AsyncDataSourcesResource:
         if "data" in response:
             return response["data"]
         return response
+
+
+class AsyncSubscriptionsResource:
+    """Async resource for agent-subscription CRUD and event polling (#3245)."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def list(self) -> List[Subscription]:
+        """List all subscriptions for the authenticated user."""
+        response = await self.client.request(method="GET", path="/v1/subscriptions")
+        data = unwrap_data(response)
+        subs = data.get("subscriptions", [])
+        return [Subscription(**s) for s in subs]
+
+    async def create(
+        self,
+        codes: List[str],
+        interval: Union[str, int],
+        name: Optional[str] = None,
+        source: Optional[str] = None,
+        tool: Optional[str] = None,
+    ) -> Subscription:
+        """Create a new subscription (watch).
+
+        Args:
+            codes: Commodity codes to watch (e.g. ["BRENT_CRUDE_USD"]).
+            interval: Friendly interval ("5m", "1h", "daily") or seconds (int).
+            name: Optional human-friendly name.
+            source: Attribution source header (defaults to "sdk-python").
+            tool: Optional attribution tool name header.
+        """
+        body = build_create_body(codes, interval, name=name)
+        headers = build_attribution_headers(source=source, tool=tool)
+        response = await self.client.request(
+            method="POST",
+            path="/v1/subscriptions",
+            json_data=body,
+            headers=headers,
+        )
+        data = unwrap_data(response)
+        sub = data.get("subscription", data)
+        return Subscription(**sub)
+
+    async def delete(self, subscription_id: str) -> bool:
+        """Delete a subscription. Returns True on success."""
+        await self.client.request(
+            method="DELETE",
+            path=f"/v1/subscriptions/{subscription_id}",
+        )
+        return True
+
+    async def events(
+        self,
+        since: Optional[int] = None,
+        limit: Optional[int] = None,
+        watch_id: Optional[str] = None,
+    ) -> SubscriptionEventsPage:
+        """Poll for subscription events newer than a cursor.
+
+        Returns a SubscriptionEventsPage with events, cursor, and has_more.
+        """
+        params: Dict[str, Any] = {}
+        if since is not None:
+            params["since"] = since
+        if limit is not None:
+            params["limit"] = limit
+        if watch_id is not None:
+            params["watch_id"] = watch_id
+
+        response = await self.client.request(
+            method="GET",
+            path="/v1/subscriptions/events",
+            params=params,
+        )
+        data = unwrap_data(response)
+        events = [SubscriptionEvent(**e) for e in data.get("events", [])]
+        cursor = data.get("cursor")
+        has_more = bool(data.get("has_more", False))
+        return SubscriptionEventsPage(events=events, cursor=cursor, has_more=has_more)

--- a/oilpriceapi/client.py
+++ b/oilpriceapi/client.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+from ._subscriptions_common import unwrap_data
 from .exceptions import (
     AuthenticationError,
     ConfigurationError,
@@ -29,7 +30,7 @@ from .exceptions import (
     TimeoutError,
     ValidationError,
 )
-from .models import DataConnectorPrice
+from .models import DataConnectorPrice, MarketBrief
 from .resources.alerts import AlertsResource
 from .resources.analytics import AnalyticsResource
 from .resources.bunker_fuels import BunkerFuelsResource
@@ -46,6 +47,7 @@ from .resources.historical import HistoricalResource
 from .resources.prices import PricesResource
 from .resources.rig_counts import RigCountsResource
 from .resources.storage import StorageResource
+from .resources.subscriptions import SubscriptionsResource
 from .resources.webhooks import WebhooksResource
 from .retry import RetryStrategy
 
@@ -176,6 +178,8 @@ class OilPriceAPI:
         self.ei = EnergyIntelligenceResource(self)
         self.webhooks = WebhooksResource(self)
         self.data_sources = DataSourcesResource(self)
+        # Agent watch subscriptions + event polling (#3245 Phase 2).
+        self.subscriptions = SubscriptionsResource(self)
         # Public, no-auth demo endpoints (/v1/demo/*).
         self.demo = DemoResource(self)
 
@@ -544,6 +548,38 @@ class OilPriceAPI:
         response = self.request('GET', '/v1/prices/data-connector', params=params)
         prices_data = response.get('data', {}).get('prices', [])
         return [DataConnectorPrice(**p) for p in prices_data]
+
+    def market_brief(
+        self,
+        codes: List[str],
+        narrative: bool = False,
+    ) -> MarketBrief:
+        """Get a multi-commodity structured (+ optional narrative) market brief.
+
+        Composes existing price/forecast data for the given commodity codes into
+        a single structured summary (#3245 Phase 1a). Counts as one request.
+
+        Args:
+            codes: Commodity codes to include (e.g. ["BRENT_CRUDE_USD", "WTI"]).
+            narrative: When True, request a natural-language narrative as well.
+
+        Returns:
+            A MarketBrief model.
+
+        Example:
+            >>> brief = client.market_brief(["BRENT_CRUDE_USD"], narrative=True)
+            >>> print(brief.commodities[0].price)
+        """
+        params: Dict[str, Any] = {"codes": ",".join(codes)}
+        if narrative:
+            params["narrative"] = "true"
+
+        response = self.request(
+            method="GET",
+            path="/v1/market-brief",
+            params=params,
+        )
+        return MarketBrief(**unwrap_data(response))
 
     def close(self):
         """Close the HTTP client and flush telemetry."""

--- a/oilpriceapi/models.py
+++ b/oilpriceapi/models.py
@@ -357,6 +357,123 @@ class WebhookTestResponse(BaseModel):
     error: Optional[str] = Field(default=None, description="Error message if test failed")
 
 
+class MarketBriefForecast(BaseModel):
+    """1-month forecast block attached to a market-brief commodity."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    point: Optional[float] = Field(default=None, description="Central forecast value")
+    low: Optional[float] = Field(default=None, description="Lower bound of the forecast range")
+    high: Optional[float] = Field(default=None, description="Upper bound of the forecast range")
+    confidence: Optional[str] = Field(default=None, description="Confidence label (e.g. high, medium, low)")
+
+
+class MarketBriefCommodity(BaseModel):
+    """A single commodity entry within a market brief."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    code: str = Field(description="Canonical commodity code (e.g. BRENT_CRUDE_USD)")
+    name: Optional[str] = Field(default=None, description="Human-readable commodity name")
+    price: Optional[float] = Field(default=None, description="Latest price value")
+    currency: Optional[str] = Field(default=None, description="Currency code")
+    change_24h_pct: Optional[float] = Field(default=None, description="24-hour percentage change")
+    forecast_1m: Optional[MarketBriefForecast] = Field(default=None, description="1-month forecast block")
+    stale: Optional[bool] = Field(default=None, description="Whether the price is considered stale")
+
+
+class MarketBrief(BaseModel):
+    """Multi-commodity structured (+ optional narrative) market summary.
+
+    Returned by ``client.market_brief(...)`` / ``await client.market_brief(...)``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    as_of: Optional[datetime] = Field(default=None, description="Timestamp the brief was composed")
+    codes: List[str] = Field(default_factory=list, description="Resolved commodity codes in the brief")
+    commodities: List[MarketBriefCommodity] = Field(
+        default_factory=list, description="Per-commodity structured data"
+    )
+    narrative: Optional[str] = Field(default=None, description="Optional natural-language narrative")
+
+    @field_validator("as_of", mode="before")
+    @classmethod
+    def parse_as_of(cls, v):
+        """Parse as_of timestamp from various formats."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v.replace("Z", "+00:00"))
+            except ValueError:
+                from dateutil import parser
+
+                return parser.parse(v)
+        return v
+
+
+class Subscription(BaseModel):
+    """An agent subscription ("watch") that periodically evaluates commodities."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    id: str = Field(description="Unique subscription identifier")
+    name: Optional[str] = Field(default=None, description="User-friendly subscription name")
+    codes: List[str] = Field(default_factory=list, description="Commodity codes being watched")
+    interval_seconds: Optional[int] = Field(default=None, description="Evaluation interval in seconds")
+    status: Optional[str] = Field(default=None, description="Subscription status (active, paused, etc.)")
+    deliver_webhook: Optional[bool] = Field(default=None, description="Whether events are delivered via webhook")
+    source: Optional[str] = Field(default=None, description="Attribution source (sdk-python, mcp, api, etc.)")
+    tool_name: Optional[str] = Field(default=None, description="Attribution tool name")
+    last_evaluated_at: Optional[datetime] = Field(default=None, description="Last evaluation timestamp")
+    next_run_at: Optional[datetime] = Field(default=None, description="Next scheduled evaluation timestamp")
+    created_at: Optional[datetime] = Field(default=None, description="Creation timestamp")
+
+    @field_validator("last_evaluated_at", "next_run_at", "created_at", mode="before")
+    @classmethod
+    def parse_datetimes(cls, v):
+        """Parse datetime fields from various formats."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v.replace("Z", "+00:00"))
+            except ValueError:
+                from dateutil import parser
+
+                return parser.parse(v)
+        return v
+
+
+class SubscriptionEvent(BaseModel):
+    """A single event emitted by a subscription, returned from the poll endpoint."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    seq: Optional[int] = Field(default=None, description="Monotonic per-user sequence cursor")
+    watch_id: Optional[str] = Field(default=None, description="Subscription (watch) that produced the event")
+    type: Optional[str] = Field(default=None, description="Event type")
+    code: Optional[str] = Field(default=None, description="Commodity code the event relates to")
+    payload: Optional[Dict[str, Any]] = Field(default=None, description="Event payload")
+    created_at: Optional[datetime] = Field(default=None, description="Event timestamp")
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def parse_created_at(cls, v):
+        """Parse created_at from various formats."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v.replace("Z", "+00:00"))
+            except ValueError:
+                from dateutil import parser
+
+                return parser.parse(v)
+        return v
+
+
 class DataConnectorPrice(BaseModel):
     """Price from connected data source (BYOS - Bring Your Own Subscription)."""
 

--- a/oilpriceapi/resources/__init__.py
+++ b/oilpriceapi/resources/__init__.py
@@ -20,6 +20,7 @@ from .historical import HistoricalResource
 from .prices import PricesResource
 from .rig_counts import RigCountsResource
 from .storage import StorageResource
+from .subscriptions import SubscriptionsResource
 from .webhooks import WebhooksResource
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "WebhooksResource",
     "DataSourcesResource",
     "DemoResource",
+    "SubscriptionsResource",
 ]

--- a/oilpriceapi/resources/subscriptions.py
+++ b/oilpriceapi/resources/subscriptions.py
@@ -1,0 +1,162 @@
+"""
+Subscriptions Resource
+
+Agent "watch" subscriptions + event polling (#3245 Phase 2). Persistent watches
+periodically evaluate commodity codes and emit events an agent can poll for.
+"""
+
+from typing import Any, Dict, List, Optional, Union, cast
+
+from .._subscriptions_common import (
+    build_attribution_headers,
+    build_create_body,
+    unwrap_data,
+)
+from ..models import Subscription, SubscriptionEvent
+
+
+class SubscriptionEventsPage:
+    """A single page of subscription events from the poll endpoint.
+
+    Attributes:
+        events: The events in this page.
+        cursor: The latest sequence number seen; pass as ``since`` next poll.
+        has_more: Whether more events are immediately available.
+    """
+
+    def __init__(self, events: List[SubscriptionEvent], cursor: Optional[int], has_more: bool) -> None:
+        self.events = events
+        self.cursor = cursor
+        self.has_more = has_more
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def __len__(self) -> int:
+        return len(self.events)
+
+    def __repr__(self) -> str:
+        return f"SubscriptionEventsPage(events={len(self.events)}, cursor={self.cursor}, has_more={self.has_more})"
+
+
+class SubscriptionsResource:
+    """Resource for agent-subscription CRUD and event polling."""
+
+    def __init__(self, client: Any) -> None:
+        """Initialize subscriptions resource.
+
+        Args:
+            client: OilPriceAPI client instance
+        """
+        self.client = client
+
+    def list(self) -> List[Subscription]:
+        """List all subscriptions for the authenticated user.
+
+        Returns:
+            List of Subscription models.
+
+        Example:
+            >>> for sub in client.subscriptions.list():
+            ...     print(sub.name, sub.codes)
+        """
+        response = self.client.request(method="GET", path="/v1/subscriptions")
+        data = unwrap_data(response)
+        subs = data.get("subscriptions", [])
+        return [Subscription(**s) for s in subs]
+
+    def create(
+        self,
+        codes: List[str],
+        interval: Union[str, int],
+        name: Optional[str] = None,
+        source: Optional[str] = None,
+        tool: Optional[str] = None,
+    ) -> Subscription:
+        """Create a new subscription (watch).
+
+        Args:
+            codes: Commodity codes to watch (e.g. ["BRENT_CRUDE_USD"]).
+            interval: Friendly interval ("5m", "1h", "daily") or seconds (int).
+            name: Optional human-friendly name.
+            source: Attribution source header (defaults to "sdk-python").
+            tool: Optional attribution tool name header.
+
+        Returns:
+            The created Subscription model.
+
+        Example:
+            >>> sub = client.subscriptions.create(
+            ...     ["BRENT_CRUDE_USD"], interval="5m", name="Brent watch"
+            ... )
+        """
+        body = build_create_body(codes, interval, name=name)
+        headers = build_attribution_headers(source=source, tool=tool)
+        response = self.client.request(
+            method="POST",
+            path="/v1/subscriptions",
+            json_data=body,
+            headers=headers,
+        )
+        data = unwrap_data(response)
+        sub = data.get("subscription", data)
+        return Subscription(**sub)
+
+    def delete(self, subscription_id: str) -> bool:
+        """Delete a subscription.
+
+        Args:
+            subscription_id: The subscription id to delete.
+
+        Returns:
+            True on success.
+
+        Example:
+            >>> client.subscriptions.delete(sub.id)
+        """
+        self.client.request(
+            method="DELETE",
+            path=f"/v1/subscriptions/{subscription_id}",
+        )
+        return True
+
+    def events(
+        self,
+        since: Optional[int] = None,
+        limit: Optional[int] = None,
+        watch_id: Optional[str] = None,
+    ) -> SubscriptionEventsPage:
+        """Poll for subscription events newer than a cursor.
+
+        Args:
+            since: Sequence cursor; only events with seq > since are returned.
+            limit: Max events to return (server clamps to its own max).
+            watch_id: Restrict to a single subscription.
+
+        Returns:
+            A SubscriptionEventsPage with events, cursor, and has_more.
+
+        Example:
+            >>> page = client.subscriptions.events(since=0)
+            >>> for event in page:
+            ...     print(event.type, event.code)
+            >>> next_page = client.subscriptions.events(since=page.cursor)
+        """
+        params: Dict[str, Any] = {}
+        if since is not None:
+            params["since"] = since
+        if limit is not None:
+            params["limit"] = limit
+        if watch_id is not None:
+            params["watch_id"] = watch_id
+
+        response = self.client.request(
+            method="GET",
+            path="/v1/subscriptions/events",
+            params=params,
+        )
+        data = unwrap_data(response)
+        events = [SubscriptionEvent(**e) for e in data.get("events", [])]
+        cursor = cast(Optional[int], data.get("cursor"))
+        has_more = bool(data.get("has_more", False))
+        return SubscriptionEventsPage(events=events, cursor=cursor, has_more=has_more)

--- a/oilpriceapi/version.py
+++ b/oilpriceapi/version.py
@@ -5,6 +5,6 @@ Single source of truth for the SDK version string.
 Used in __init__.py, client.py, and async_client.py.
 """
 
-__version__ = "1.8.1"
+__version__ = "1.9.0"
 SDK_VERSION = __version__
 SDK_NAME = "oilpriceapi-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oilpriceapi"
-version = "1.8.1"
+version = "1.9.0"
 description = "Official Python SDK for OilPriceAPI - Real-time and historical oil prices"
 authors = [
     {name = "OilPriceAPI", email = "support@oilpriceapi.com"}

--- a/tests/integration/test_live_subscriptions.py
+++ b/tests/integration/test_live_subscriptions.py
@@ -1,0 +1,57 @@
+"""
+Live integration tests for market-brief + subscriptions (#3245).
+
+These hit the REAL OilPriceAPI and require a key in the ``OILPRICEAPI_TEST_KEY``
+environment variable. They are marked ``live`` and excluded from the default
+unit gate (``--ignore=tests/integration``). They are skipped automatically when
+the key is absent (e.g. on forks / CI without the secret).
+
+Read-only by default: we fetch a market brief and list subscriptions. No
+subscriptions are created or deleted, so nothing is written to production.
+
+The API rate limit is 1 request/second, so calls are spaced with small sleeps.
+"""
+
+import os
+import time
+
+import pytest
+
+from oilpriceapi import MarketBrief, OilPriceAPI
+
+TEST_KEY = os.environ.get("OILPRICEAPI_TEST_KEY")
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not TEST_KEY,
+        reason="OILPRICEAPI_TEST_KEY not set; skipping live subscription tests",
+    ),
+]
+
+RATE_LIMIT_SLEEP = 1.1
+
+
+@pytest.fixture
+def client():
+    c = OilPriceAPI(api_key=TEST_KEY)
+    yield c
+    c.close()
+
+
+def test_market_brief_live(client):
+    """market_brief returns a brief with a price for a known commodity."""
+    brief = client.market_brief(["BRENT_CRUDE_USD"])
+    assert isinstance(brief, MarketBrief)
+    assert brief.commodities, "expected at least one commodity in the brief"
+    commodity = brief.commodities[0]
+    assert commodity.code
+    assert commodity.price is not None and commodity.price > 0
+    time.sleep(RATE_LIMIT_SLEEP)
+
+
+def test_subscriptions_list_live(client):
+    """subscriptions.list() returns a list (possibly empty) without error."""
+    subs = client.subscriptions.list()
+    assert isinstance(subs, list)

--- a/tests/unit/test_async_subscriptions_resource.py
+++ b/tests/unit/test_async_subscriptions_resource.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for AsyncSubscriptionsResource + async market_brief, #3245.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from oilpriceapi import (
+    AsyncOilPriceAPI,
+    MarketBrief,
+    Subscription,
+    SubscriptionEvent,
+    SubscriptionEventsPage,
+)
+from oilpriceapi._subscriptions_common import DEFAULT_SOURCE
+
+
+@pytest.fixture
+def client():
+    return AsyncOilPriceAPI(api_key="test_key")
+
+
+class TestAsyncSubscriptionsResource:
+    @pytest.mark.asyncio
+    async def test_list(self, client):
+        payload = {
+            "data": {
+                "subscriptions": [
+                    {"id": "abc-123", "codes": ["BRENT_CRUDE_USD"], "interval_seconds": 300, "status": "active"}
+                ]
+            }
+        }
+        with patch.object(client, "request", new=AsyncMock(return_value=payload)):
+            subs = await client.subscriptions.list()
+        assert len(subs) == 1
+        assert isinstance(subs[0], Subscription)
+        assert subs[0].id == "abc-123"
+
+    @pytest.mark.asyncio
+    async def test_create_maps_interval_and_headers(self, client):
+        payload = {"data": {"subscription": {"id": "n1", "codes": ["WTI_USD"], "interval_seconds": 3600}}}
+        mock = AsyncMock(return_value=payload)
+        with patch.object(client, "request", new=mock):
+            sub = await client.subscriptions.create(["WTI_USD"], interval="1h", name="hr")
+        assert isinstance(sub, Subscription)
+        _, kwargs = mock.call_args
+        assert kwargs["json_data"]["interval_seconds"] == 3600
+        assert kwargs["json_data"]["name"] == "hr"
+        assert kwargs["headers"]["X-OPA-Source"] == DEFAULT_SOURCE
+
+    @pytest.mark.asyncio
+    async def test_create_custom_source(self, client):
+        payload = {"data": {"subscription": {"id": "x", "codes": ["WTI_USD"], "interval_seconds": 60}}}
+        mock = AsyncMock(return_value=payload)
+        with patch.object(client, "request", new=mock):
+            await client.subscriptions.create(["WTI_USD"], interval=60, source="mcp", tool="claude")
+        _, kwargs = mock.call_args
+        assert kwargs["headers"] == {"X-OPA-Source": "mcp", "X-OPA-Tool": "claude"}
+
+    @pytest.mark.asyncio
+    async def test_delete(self, client):
+        mock = AsyncMock(return_value=None)
+        with patch.object(client, "request", new=mock):
+            assert await client.subscriptions.delete("abc-123") is True
+        _, kwargs = mock.call_args
+        assert kwargs["method"] == "DELETE"
+        assert kwargs["path"] == "/v1/subscriptions/abc-123"
+
+    @pytest.mark.asyncio
+    async def test_events(self, client):
+        payload = {
+            "data": {
+                "cursor": 7,
+                "has_more": False,
+                "events": [{"seq": 7, "watch_id": "abc-123", "type": "threshold", "code": "WTI_USD"}],
+            }
+        }
+        mock = AsyncMock(return_value=payload)
+        with patch.object(client, "request", new=mock):
+            page = await client.subscriptions.events(since=6, limit=10)
+        assert isinstance(page, SubscriptionEventsPage)
+        assert page.cursor == 7
+        assert page.has_more is False
+        assert len(page) == 1
+        assert isinstance(page.events[0], SubscriptionEvent)
+        _, kwargs = mock.call_args
+        assert kwargs["params"] == {"since": 6, "limit": 10}
+
+
+class TestAsyncMarketBrief:
+    @pytest.mark.asyncio
+    async def test_market_brief(self, client):
+        payload = {
+            "data": {
+                "codes": ["BRENT_CRUDE_USD"],
+                "commodities": [
+                    {"code": "BRENT_CRUDE_USD", "price": 78.5, "currency": "USD"}
+                ],
+            }
+        }
+        mock = AsyncMock(return_value=payload)
+        with patch.object(client, "request", new=mock):
+            brief = await client.market_brief(["BRENT_CRUDE_USD"], narrative=True)
+        assert isinstance(brief, MarketBrief)
+        assert brief.commodities[0].price == 78.5
+        _, kwargs = mock.call_args
+        assert kwargs["params"]["codes"] == "BRENT_CRUDE_USD"
+        assert kwargs["params"]["narrative"] == "true"

--- a/tests/unit/test_subscriptions_resource.py
+++ b/tests/unit/test_subscriptions_resource.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for SubscriptionsResource + market_brief (sync), #3245.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from oilpriceapi import (
+    MarketBrief,
+    OilPriceAPI,
+    Subscription,
+    SubscriptionEvent,
+    SubscriptionEventsPage,
+)
+from oilpriceapi._subscriptions_common import (
+    DEFAULT_SOURCE,
+    build_attribution_headers,
+    build_create_body,
+    normalize_interval,
+)
+
+
+class TestIntervalMapping:
+    """Friendly interval → interval_seconds conversion."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("1m", 60),
+            ("5m", 300),
+            ("15m", 900),
+            ("1h", 3600),
+            ("hourly", 3600),
+            ("daily", 86400),
+            ("1d", 86400),
+            ("30s", 30),
+            ("2h", 7200),
+            ("300", 300),
+            (300, 300),
+            ("5M", 300),  # case-insensitive alias
+            (" 5m ", 300),  # whitespace tolerant
+        ],
+    )
+    def test_normalize_interval(self, value, expected):
+        assert normalize_interval(value) == expected
+
+    @pytest.mark.parametrize("bad", ["", "abc", "0", 0, -5, "-1h", "5x", True])
+    def test_normalize_interval_invalid(self, bad):
+        with pytest.raises(ValueError):
+            normalize_interval(bad)
+
+    def test_build_create_body(self):
+        body = build_create_body(["BRENT_CRUDE_USD"], "5m", name="Brent")
+        assert body == {
+            "codes": ["BRENT_CRUDE_USD"],
+            "interval_seconds": 300,
+            "name": "Brent",
+        }
+
+    def test_build_create_body_no_name(self):
+        body = build_create_body(["WTI_USD"], 600)
+        assert "name" not in body
+        assert body["interval_seconds"] == 600
+
+    def test_attribution_headers_default_source(self):
+        assert build_attribution_headers() == {"X-OPA-Source": DEFAULT_SOURCE}
+
+    def test_attribution_headers_custom(self):
+        headers = build_attribution_headers(source="mcp", tool="claude")
+        assert headers == {"X-OPA-Source": "mcp", "X-OPA-Tool": "claude"}
+
+
+class TestSubscriptionsResource:
+    @pytest.fixture
+    def client(self):
+        return OilPriceAPI(api_key="test_key")
+
+    def test_list(self, client):
+        payload = {
+            "status": "success",
+            "data": {
+                "subscriptions": [
+                    {
+                        "id": "abc-123",
+                        "name": "Brent watch",
+                        "codes": ["BRENT_CRUDE_USD"],
+                        "interval_seconds": 300,
+                        "status": "active",
+                    }
+                ]
+            },
+        }
+        with patch.object(client, "request", return_value=payload):
+            subs = client.subscriptions.list()
+        assert len(subs) == 1
+        assert isinstance(subs[0], Subscription)
+        assert subs[0].id == "abc-123"
+        assert subs[0].codes == ["BRENT_CRUDE_USD"]
+
+    def test_create_maps_interval_and_headers(self, client):
+        payload = {
+            "status": "success",
+            "data": {
+                "subscription": {
+                    "id": "new-1",
+                    "name": "My watch",
+                    "codes": ["WTI_USD"],
+                    "interval_seconds": 300,
+                    "status": "active",
+                }
+            },
+        }
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            sub = client.subscriptions.create(["WTI_USD"], interval="5m", name="My watch")
+
+        assert isinstance(sub, Subscription)
+        assert sub.id == "new-1"
+        _, kwargs = mock_req.call_args
+        assert kwargs["json_data"]["interval_seconds"] == 300
+        assert kwargs["json_data"]["codes"] == ["WTI_USD"]
+        assert kwargs["json_data"]["name"] == "My watch"
+        # Default attribution source applied.
+        assert kwargs["headers"]["X-OPA-Source"] == DEFAULT_SOURCE
+
+    def test_create_custom_source_and_tool(self, client):
+        payload = {"data": {"subscription": {"id": "x", "codes": ["WTI_USD"], "interval_seconds": 60}}}
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            client.subscriptions.create(["WTI_USD"], interval=60, source="mcp", tool="claude")
+        _, kwargs = mock_req.call_args
+        assert kwargs["headers"] == {"X-OPA-Source": "mcp", "X-OPA-Tool": "claude"}
+
+    def test_delete(self, client):
+        with patch.object(client, "request", return_value=None) as mock_req:
+            assert client.subscriptions.delete("abc-123") is True
+        args, kwargs = mock_req.call_args
+        assert kwargs["method"] == "DELETE"
+        assert kwargs["path"] == "/v1/subscriptions/abc-123"
+
+    def test_events(self, client):
+        payload = {
+            "status": "success",
+            "data": {
+                "cursor": 42,
+                "has_more": True,
+                "events": [
+                    {"seq": 41, "watch_id": "abc-123", "type": "threshold", "code": "BRENT_CRUDE_USD"},
+                    {"seq": 42, "watch_id": "abc-123", "type": "threshold", "code": "BRENT_CRUDE_USD"},
+                ],
+            },
+        }
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            page = client.subscriptions.events(since=40)
+
+        assert isinstance(page, SubscriptionEventsPage)
+        assert page.cursor == 42
+        assert page.has_more is True
+        assert len(page) == 2
+        assert all(isinstance(e, SubscriptionEvent) for e in page)
+        _, kwargs = mock_req.call_args
+        assert kwargs["params"]["since"] == 40
+
+    def test_events_no_since(self, client):
+        payload = {"data": {"cursor": 0, "has_more": False, "events": []}}
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            page = client.subscriptions.events()
+        assert page.has_more is False
+        assert len(page) == 0
+        _, kwargs = mock_req.call_args
+        assert kwargs["params"] == {}
+
+
+class TestMarketBrief:
+    @pytest.fixture
+    def client(self):
+        return OilPriceAPI(api_key="test_key")
+
+    def test_market_brief(self, client):
+        payload = {
+            "status": "success",
+            "data": {
+                "as_of": "2026-06-21T12:00:00Z",
+                "codes": ["BRENT_CRUDE_USD"],
+                "commodities": [
+                    {
+                        "code": "BRENT_CRUDE_USD",
+                        "name": "Brent Crude",
+                        "price": 78.5,
+                        "currency": "USD",
+                        "change_24h_pct": 1.2,
+                        "forecast_1m": {"point": 80.0, "low": 76.0, "high": 84.0, "confidence": "medium"},
+                        "stale": False,
+                    }
+                ],
+            },
+        }
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            brief = client.market_brief(["BRENT_CRUDE_USD"])
+
+        assert isinstance(brief, MarketBrief)
+        assert brief.codes == ["BRENT_CRUDE_USD"]
+        assert brief.commodities[0].price == 78.5
+        assert brief.commodities[0].forecast_1m.point == 80.0
+        _, kwargs = mock_req.call_args
+        assert kwargs["params"]["codes"] == "BRENT_CRUDE_USD"
+        assert "narrative" not in kwargs["params"]
+
+    def test_market_brief_narrative(self, client):
+        payload = {
+            "data": {
+                "codes": ["WTI_USD", "BRENT_CRUDE_USD"],
+                "commodities": [],
+                "narrative": "Crude markets edged higher.",
+            }
+        }
+        with patch.object(client, "request", return_value=payload) as mock_req:
+            brief = client.market_brief(["WTI_USD", "BRENT_CRUDE_USD"], narrative=True)
+        assert brief.narrative == "Crude markets edged higher."
+        _, kwargs = mock_req.call_args
+        assert kwargs["params"]["codes"] == "WTI_USD,BRENT_CRUDE_USD"
+        assert kwargs["params"]["narrative"] == "true"


### PR DESCRIPTION
Adds Python SDK support for the now-live #3245 endpoints on both the **sync** (`OilPriceAPI`) and **async** (`AsyncOilPriceAPI`) clients.

## Methods added

**Market brief**
- `client.market_brief(codes, narrative=False)` → `MarketBrief`
- `await client.market_brief(...)` (async mirror)

**Agent subscriptions** (`client.subscriptions` / `await client.subscriptions`)
- `.list()` → `List[Subscription]`
- `.create(codes, interval, name=None, source=None, tool=None)` → `Subscription`
  - friendly `interval` mapping: `"5m"`/`"1h"`/`"daily"` (and `"<n>s/m/h/d"` / raw int) → `interval_seconds`
  - `X-OPA-Source` / `X-OPA-Tool` attribution headers (default source `sdk-python`)
- `.delete(id)` → `bool`
- `.events(since=None, limit=None, watch_id=None)` → `SubscriptionEventsPage` (iterable; `.events`, `.cursor`, `.has_more`)

**Models** (exported from package root): `MarketBrief`, `MarketBriefCommodity`, `MarketBriefForecast`, `Subscription`, `SubscriptionEvent`, plus `SubscriptionEventsPage`.

Version bumped **1.8.1 → 1.9.0** (`pyproject.toml` + `version.py`). README updated with sync + async usage examples. No release tag cut.

## Live-test result

A read-only live integration test was added (`tests/integration/test_live_subscriptions.py`, marked `live`): `market_brief(["BRENT_CRUDE_USD"])` returns 200 + a positive price, and `subscriptions.list()` returns 200. It uses `OILPRICEAPI_TEST_KEY` and **skips automatically when absent** (no prod writes in CI by default).

**Not executed against production in this run** — no `OILPRICEAPI_TEST_KEY` was available in the environment, so the live tests skipped as designed (2 skipped). The mocked unit tests fully exercise the request shapes, interval mapping, attribution headers, and response parsing.

## Gates

| Gate | Command | Result |
|------|---------|--------|
| mypy | `mypy oilpriceapi/ --ignore-missing-imports` | ✅ Success, no issues (43 files) |
| ruff | `ruff check oilpriceapi/` | ✅ All checks passed |
| pytest | `pytest tests/ --ignore=tests/integration --ignore=tests/contract -m 'not slow' --cov=oilpriceapi` | ✅ 311 passed, 9 skipped, cov 59.33% (>50% gate) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)