### PR TITLE
fix(telemetry): send X-SDK-Language and X-Client-Type headers

### DIFF
--- a/oilpriceapi/async_client.py
+++ b/oilpriceapi/async_client.py
@@ -119,6 +119,8 @@ class AsyncOilPriceAPI:
             "User-Agent": f"{SDK_NAME}/{SDK_VERSION} python/{python_version}",
             "X-SDK-Name": SDK_NAME,
             "X-SDK-Version": SDK_VERSION,
+            "X-SDK-Language": "python",
+            "X-Client-Type": "sdk",
         }
 
         # Add optional telemetry headers (10% bonus for app_url!)

--- a/oilpriceapi/client.py
+++ b/oilpriceapi/client.py
@@ -142,6 +142,8 @@ class OilPriceAPI:
             "User-Agent": f"{SDK_NAME}/{SDK_VERSION} python/{python_version}",
             "X-SDK-Name": SDK_NAME,
             "X-SDK-Version": SDK_VERSION,
+            "X-SDK-Language": "python",
+            "X-Client-Type": "sdk",
         }
 
         # Add optional telemetry headers (10% bonus for app_url!)

--- a/tests/test_telemetry_headers.py
+++ b/tests/test_telemetry_headers.py
@@ -1,0 +1,107 @@
+"""
+Tests for SDK telemetry headers (issue #4).
+
+The API tracks SDK adoption via request headers. Every SDK request must
+identify itself with:
+
+    X-SDK-Language: python
+    X-SDK-Version: <version>
+    X-Client-Type: sdk
+
+Issue #4 reported that ``X-SDK-Language`` and ``X-Client-Type`` were never
+reaching the API (0/166 requests), making it impossible to distinguish SDK
+traffic from manual ``python-requests``/``python-httpx`` calls. These tests
+encode the acceptance criteria for both the sync and async clients, asserting
+the headers are both configured on the client and actually transmitted on the
+wire.
+"""
+
+import asyncio
+
+import httpx
+
+from oilpriceapi import OilPriceAPI
+from oilpriceapi.async_client import AsyncOilPriceAPI
+from oilpriceapi.version import SDK_VERSION
+
+
+class TestSyncTelemetryHeaders:
+    """Sync client must advertise SDK telemetry headers."""
+
+    def test_headers_include_sdk_language(self):
+        client = OilPriceAPI(api_key="test_key")
+        assert client.headers["X-SDK-Language"] == "python"
+
+    def test_headers_include_client_type(self):
+        client = OilPriceAPI(api_key="test_key")
+        assert client.headers["X-Client-Type"] == "sdk"
+
+    def test_headers_include_sdk_version(self):
+        client = OilPriceAPI(api_key="test_key")
+        assert client.headers["X-SDK-Version"] == SDK_VERSION
+
+    def test_telemetry_headers_sent_on_request(self):
+        """Headers must actually be transmitted, not just stored locally."""
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.update(request.headers)
+            return httpx.Response(
+                200,
+                json={"data": {"price": 80.0, "commodity": "BRENT_CRUDE_USD"}},
+            )
+
+        client = OilPriceAPI(api_key="test_key")
+        client._client = httpx.Client(
+            base_url=client.base_url,
+            headers=client.headers,
+            transport=httpx.MockTransport(handler),
+        )
+        client.request("GET", "/v1/prices/latest")
+
+        assert captured.get("x-sdk-language") == "python"
+        assert captured.get("x-client-type") == "sdk"
+        assert captured.get("x-sdk-version") == SDK_VERSION
+
+
+class TestAsyncTelemetryHeaders:
+    """Async client must advertise SDK telemetry headers."""
+
+    def test_headers_include_sdk_language(self):
+        client = AsyncOilPriceAPI(api_key="test_key")
+        assert client.headers["X-SDK-Language"] == "python"
+
+    def test_headers_include_client_type(self):
+        client = AsyncOilPriceAPI(api_key="test_key")
+        assert client.headers["X-Client-Type"] == "sdk"
+
+    def test_headers_include_sdk_version(self):
+        client = AsyncOilPriceAPI(api_key="test_key")
+        assert client.headers["X-SDK-Version"] == SDK_VERSION
+
+    def test_telemetry_headers_sent_on_request(self):
+        """Async requests must transmit telemetry headers on the wire."""
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.update(request.headers)
+            return httpx.Response(
+                200,
+                json={"data": {"price": 80.0, "commodity": "BRENT_CRUDE_USD"}},
+            )
+
+        async def run():
+            client = AsyncOilPriceAPI(api_key="test_key")
+            client._client = httpx.AsyncClient(
+                base_url=client.base_url,
+                headers=client.headers,
+                transport=httpx.MockTransport(handler),
+            )
+            await client.request("GET", "/v1/prices/latest")
+            await client._client.aclose()
+
+        asyncio.run(run())
+
+        assert captured.get("x-sdk-language") == "python"
+        assert captured.get("x-client-type") == "sdk"
+        assert captured.get("x-sdk-version") == SDK_VERSION


### PR DESCRIPTION
Closes #4

## What

The sync (`OilPriceAPI`) and async (`AsyncOilPriceAPI`) clients already sent `X-SDK-Name` and `X-SDK-Version`, but omitted the two telemetry headers the API uses to distinguish SDK traffic from raw `python-httpx`/`python-requests` calls. As reported in #4, 0/166 recent Python requests carried `X-SDK-Language` and `X-Client-Type`.

This adds the two missing headers to both clients (additive, 4 lines):

```
X-SDK-Language: python
X-Client-Type: sdk
```

`X-SDK-Version` was already present and is retained.

## How (strict TDD: red → green → refactor)

1. **RED** — Added `tests/test_telemetry_headers.py` encoding the issue's acceptance criteria for both sync and async clients: headers are configured AND actually transmitted on the wire (via `httpx.MockTransport` capturing the outbound request). 6 of 8 assertions failed against the unpatched clients.
2. **GREEN** — Added `X-SDK-Language: python` and `X-Client-Type: sdk` to the header dict in `client.py` and `async_client.py`. All 8 new tests pass.
3. **REFACTOR** — None needed; change is minimal and already clean.

## Test evidence

```
tests/test_telemetry_headers.py ........  [100%]
8 passed

# Full CI gate
ruff check oilpriceapi/        -> All checks passed!
pytest tests/ (not slow)       -> 328 passed (was 320 + 8 new)
mypy oilpriceapi/client.py oilpriceapi/async_client.py --ignore-missing-imports -> Success: no issues found
```

Note: a full-tree `mypy oilpriceapi/` run in this local env errors only inside the third-party `numpy/__init__.pyi` stub under Python 3.14 (`type` statement support); this failure is identical on the unmodified baseline and is unrelated to this change. The changed files type-check cleanly, and CI runs on the supported Python 3.8–3.12 targets.

## Scope

Additive only. No migrations, Stripe, auth, routes, or customer-facing copy touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)