### PR TITLE
release: v1.10.0 — indicators module + README/link corrections (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-03
+
 ### Added
 
 - **Analysis Resource (Technical Indicators)**: `client.analysis` with `with_indicators(df, indicators=[...])` DataFrame helper and direct methods `sma()`, `ema()`, `rsi()`, `macd()`, `bollinger_bands()`, `atr()`. Pure pandas/numpy implementation, no new dependencies. Closes #3.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 [![Coverage](https://codecov.io/gh/oilpriceapi/python-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/oilpriceapi/python-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**[Get Free API Key](https://www.oilpriceapi.com/signup?utm_source=pypi&utm_medium=sdk&utm_campaign=readme)** • **[Documentation](https://docs.oilpriceapi.com/sdk/python)** • **[Pricing](https://www.oilpriceapi.com/pricing?utm_source=pypi&utm_medium=sdk&utm_campaign=pricing)**
+**[Get Free API Key](https://www.oilpriceapi.com/signup?utm_source=pypi&utm_medium=sdk&utm_campaign=readme)** • **[Documentation](https://docs.oilpriceapi.com/)** • **[Pricing](https://www.oilpriceapi.com/pricing?utm_source=pypi&utm_medium=sdk&utm_campaign=pricing)**
 
 The official Python SDK for [OilPriceAPI](https://oilpriceapi.com) - Real-time and historical oil prices for Brent Crude, WTI, Natural Gas, and more.
 
-> **📝 Documentation Status**: All code examples shown are tested and working. Technical indicators are available as of v1.9.0 (see [Technical Indicators](#technical-indicators-new-in-v190)); see our [GitHub Issues](https://github.com/OilpriceAPI/python-sdk/issues) for the roadmap.
+> **📝 Documentation Status**: All code examples shown are tested and working. Technical indicators are available as of v1.10.0 (see [Technical Indicators](#technical-indicators-new-in-v1100)); see our [GitHub Issues](https://github.com/OilpriceAPI/python-sdk/issues) for the roadmap.
 
 **Quick start:**
 
@@ -63,7 +63,7 @@ print(f"Retrieved {len(df)} data points")
 print(df.head())
 ```
 
-### Technical Indicators (New in v1.9.0)
+### Technical Indicators (New in v1.10.0)
 
 Add technical analysis indicators to any price DataFrame. Implemented in pure
 pandas/numpy, so no extra dependencies beyond the optional `[pandas]` extra.
@@ -555,7 +555,7 @@ async with AsyncOilPriceAPI() as client:
 
 ## 📚 Documentation
 
-**[Complete SDK Documentation →](docs/index.md)** | **[Online Docs →](https://docs.oilpriceapi.com/sdk/python)**
+**[Complete SDK Documentation →](docs/index.md)** | **[Online Docs →](https://docs.oilpriceapi.com/)**
 
 **[⚡ Performance Guide →](docs/PERFORMANCE_GUIDE.md)** — expected response times, recommended timeouts, optimization best practices, and troubleshooting for slow queries.
 
@@ -802,7 +802,7 @@ Contributions are welcome! Please see our [Contributing Guide](https://github.co
 
 - 📧 Email: support@oilpriceapi.com
 - 🐛 Issues: [GitHub Issues](https://github.com/oilpriceapi/python-sdk/issues)
-- 📖 Docs: [Documentation](https://docs.oilpriceapi.com/sdk/python)
+- 📖 Docs: [Documentation](https://docs.oilpriceapi.com/)
 
 ## 🔗 Links
 

--- a/oilpriceapi/version.py
+++ b/oilpriceapi/version.py
@@ -5,6 +5,6 @@ Single source of truth for the SDK version string.
 Used in __init__.py, client.py, and async_client.py.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 SDK_VERSION = __version__
 SDK_NAME = "oilpriceapi-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oilpriceapi"
-version = "1.9.0"
+version = "1.10.0"
 description = "Official Python SDK for OilPriceAPI - Real-time and historical oil prices"
 authors = [
     {name = "OilPriceAPI", email = "support@oilpriceapi.com"}

--- a/tests/integration/test_demo_contract.py
+++ b/tests/integration/test_demo_contract.py
@@ -94,11 +94,13 @@ class TestDemoCommoditiesContract:
         assert isinstance(catalog, dict)  # grouped by category
 
         meta = data["meta"]
-        # Contract: 442 commodities in the catalog, meta.total agrees with the
-        # flattened catalog size.
+        # Contract: meta.total agrees with the flattened catalog size and the
+        # catalog is large (400+). Do NOT pin the exact count — the live
+        # catalog legitimately grows/shrinks (442 when written, 436 on
+        # 2026-07-03), and an exact pin turns catalog curation into failures.
         flattened = sum(len(v) for v in catalog.values())
         assert meta["total"] == flattened
-        assert meta["total"] == 442
+        assert meta["total"] >= 400
 
         # meta.free_commodities is present and matches the 9 free-tier codes.
         assert "free_commodities" in meta


### PR DESCRIPTION
Closes #43. PyPI 1.9.0 lacks the `client.analysis` indicators module the README advertises ('New in v1.9.0') — it was committed after the tag. This bumps to 1.10.0 so the published package matches the docs, fixes 3 dead /sdk/python links (404 — even the docs site's own nav route is missing, separate issue), and un-pins a brittle exact-count assertion against the live demo catalog (442→436 drift).

After merge: create GitHub release v1.10.0 → publish.yml (OIDC trusted publishing) ships to PyPI. Verify: `pip install oilpriceapi==1.10.0 && python -c "from oilpriceapi import OilPriceAPI; print('analysis ok')"`

330/386 unit+integration tests pass locally (56 skipped-no-key, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)