### PR TITLE
docs: embedder-segment quick start + fix weekly-health workflow (#44)

### DIFF
--- a/.github/workflows/weekly-health.yml
+++ b/.github/workflows/weekly-health.yml
@@ -25,11 +25,24 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
 
+      # OILPRICEAPI_TEST_KEY currently resolves empty at runtime (see PR).
+      # Guard at the shell level so the job passes loudly (::warning::) instead
+      # of failing or silently skipping every test.
       - name: Run integration tests
-        run: pytest tests/ -m 'integration' -v --timeout=60
+        run: |
+          if [ -z "$OILPRICEAPI_KEY" ]; then
+            echo "::warning::OILPRICEAPI_TEST_KEY secret is empty/unset - live integration tests skipped"
+            exit 0
+          fi
+          pytest tests/ -m 'integration' -v --no-cov --timeout=60
 
       - name: Run contract tests
-        run: pytest tests/ -m 'contract' -v --timeout=60
+        run: |
+          if [ -z "$OILPRICEAPI_KEY" ]; then
+            echo "::warning::OILPRICEAPI_TEST_KEY secret is empty/unset - contract tests skipped"
+            exit 0
+          fi
+          pytest tests/ -m 'contract' -v --no-cov --timeout=60
 
       - name: Check for dependency vulnerabilities
         run: |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ for price in prices:
     print(f"{price.commodity}: ${price.value:.2f}")
 ```
 
+### Beyond Oil — Gas, LNG, Carbon & Fuels
+
+The same client covers EU ETS carbon, European gas (TTF), LNG (JKM), and marine/road/aviation fuels — for maritime compliance (EU ETS / FuelEU Maritime), fleet & logistics fuel costing, LNG and European gas analytics, and CBAM reporting.
+
+```python
+# EU ETS carbon allowances (EUAs) — spot price in EUR
+eua = client.prices.get("EU_CARBON_EUR")
+print(f"EU carbon: €{eua.value:.2f}")  # €XX.XX per tonne CO2
+
+# Dutch TTF natural gas — futures curve via slug helpers
+# (other slugs: "lng-jkm", "eua-carbon", "uk-carbon", "natural-gas")
+ttf = client.futures.latest("ttf-gas")
+print(ttf["front_month"]["last_price"])  # front-month, €XX.XX/MWh
+
+# Marine bunker fuels (VLSFO / MGO / IFO380) at a specific port
+rotterdam = client.bunker_fuels.port("RTM")  # 3-letter port codes: SIN, RTM, FUJ, ...
+for fuel in rotterdam["prices"]:
+    print(f"{fuel['grade']}: ${fuel['price']}/{fuel['unit']}")  # VLSFO: $XXX.XX/MT
+```
+
+Spot codes for these markets also work with `client.prices.get()` / `get_multiple()`: `DUTCH_TTF_EUR`, `JKM_LNG_USD`, `VLSFO_USD`, `JET_FUEL_USD`, `DIESEL_USD`, `NATURAL_GAS_USD`. (Futures and bunker endpoints require a plan with futures data — spot prices work on every tier.)
+
 ### Historical Data with Pandas
 
 ```python

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -5,7 +5,14 @@ Shared configuration for contract tests.
 import os
 import pytest
 from pathlib import Path
-from dotenv import dotenv_values
+try:
+    from dotenv import dotenv_values
+except ImportError:
+    # python-dotenv is optional (not in the [dev] extra). In CI the API key
+    # comes from the environment, so don't make the contract suite
+    # uncollectable when dotenv isn't installed.
+    def dotenv_values(_path):  # type: ignore[misc]
+        return {}
 from oilpriceapi import OilPriceAPI
 
 # Load .env file from project root
@@ -16,15 +23,17 @@ env_path = project_root / '.env'
 env_vars = dotenv_values(env_path)
 
 # Get API credentials
-API_KEY = env_vars.get('OILPRICEAPI_KEY')
-BASE_URL = env_vars.get('OILPRICEAPI_BASE_URL', 'https://api.oilpriceapi.com')
+# Prefer .env for local dev, fall back to the environment for CI
+# (weekly-health.yml sets OILPRICEAPI_KEY from the OILPRICEAPI_TEST_KEY secret).
+API_KEY = env_vars.get('OILPRICEAPI_KEY') or os.environ.get('OILPRICEAPI_KEY')
+BASE_URL = env_vars.get('OILPRICEAPI_BASE_URL') or os.environ.get('OILPRICEAPI_BASE_URL', 'https://api.oilpriceapi.com')
 
 
 @pytest.fixture(scope="session")
 def api_key():
     """Provide API key for tests."""
     if not API_KEY:
-        pytest.skip("OILPRICEAPI_KEY not found in .env file")
+        pytest.skip("OILPRICEAPI_KEY not found in .env file or environment")
     return API_KEY
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,8 +26,10 @@ env_path = project_root / '.env'
 env_vars = dotenv_values(env_path)
 
 # Get API credentials
-API_KEY = env_vars.get('OILPRICEAPI_KEY')
-BASE_URL = env_vars.get('OILPRICEAPI_BASE_URL', 'https://api.oilpriceapi.com')
+# Prefer .env for local dev, fall back to the environment for CI
+# (weekly-health.yml sets OILPRICEAPI_KEY from the OILPRICEAPI_TEST_KEY secret).
+API_KEY = env_vars.get('OILPRICEAPI_KEY') or os.environ.get('OILPRICEAPI_KEY')
+BASE_URL = env_vars.get('OILPRICEAPI_BASE_URL') or os.environ.get('OILPRICEAPI_BASE_URL', 'https://api.oilpriceapi.com')
 
 # CI shares a single 1-request/second API key across repositories, so live
 # tests can collide and get HTTP 429 (RateLimitError) through no fault of the
@@ -52,7 +54,7 @@ def _throttle_live_calls():
 def api_key():
     """Provide API key for tests."""
     if not API_KEY:
-        pytest.skip("OILPRICEAPI_KEY not found in .env file")
+        pytest.skip("OILPRICEAPI_KEY not found in .env file or environment")
     return API_KEY
 
 


### PR DESCRIPTION
Closes #44.

## 1. README: "Beyond Oil — Gas, LNG, Carbon & Fuels"

New compact section immediately after the first quick-start example (Brent/WTI stays first). Three runnable examples using the real SDK surface:

- `client.prices.get("EU_CARBON_EUR")` — EU ETS carbon spot
- `client.futures.latest("ttf-gas")` — TTF futures curve via the slug helpers (`lng-jkm`, `eua-carbon`, `uk-carbon` also called out)
- `client.bunker_fuels.port("RTM")` — VLSFO/MGO/IFO380 at a port

One sentence names the audiences: maritime compliance (EU ETS / FuelEU Maritime), fleet & logistics, LNG/European gas analytics, CBAM. Notes which spot codes work on every tier vs. futures-gated endpoints.

Details verified against the backend, not the docstrings: port codes are **3-letter** (`RTM`, `SIN`, `FUJ` — the route constraint is `/[A-Z]{3}/`, so the existing docstring examples like `"SINGAPORE"` would 404), and the port response's `prices` is an **array** of `{grade, price, unit}` objects, not a keyed hash. No fabricated price values — placeholder shapes only.

## 2. weekly-health.yml — why it failed every run, then went silent

**Evidence (run 26766667944, 2026-06-01, representative of all 10+ failures):**

```
pytest: error: unrecognized arguments: --timeout=60
##[error]Process completed with exit code 4.
```

`pytest-timeout` wasn't installed — it was only added to the `[dev]` extra on 2026-06-21 (#29), after the last scheduled run. Every weekly run failed in ~25s at the integration step.

**Why it went silent after Jun 1:** GitHub auto-disabled the schedule — `gh workflow list --all` shows `Weekly SDK Health Check  disabled_inactivity`. Re-enabled via `gh workflow enable` so the Monday 14:00 UTC cron resumes.

**Three more latent failures it would have hit next, all fixed here:**

1. **Coverage gate:** `pyproject.toml` addopts enforce `--cov-fail-under=50`; a marker-filtered run (`-m integration`) can never meet it. Added `--no-cov` (same reason live-tests.yml uses it).
2. **Secret resolves empty:** `OILPRICEAPI_TEST_KEY` exists in `gh secret list` but resolves to an **empty string** at runtime — today's live-tests run also logs `OILPRICEAPI_TEST_KEY not set; skipping live tests.` Added a shell-level `[ -z "$OILPRICEAPI_KEY" ]` guard that emits a `::warning::` and exits 0, so the job passes loudly instead of failing or silently skipping. **Action for Karl:** re-populate the `OILPRICEAPI_TEST_KEY` secret with a real key — until then the health check runs green-with-warning but exercises no live calls.
3. **Conftests never read the env var:** both integration and contract conftests read `OILPRICEAPI_KEY` from a `.env` _file_ only (`dotenv_values`), so even a valid secret would have tested nothing. They now fall back to `os.environ`. Also made the contract conftest's `dotenv` import optional — `python-dotenv` isn't a dev dependency, so contract collection crashed without it.

## Verification

- Unit suite: **303 passed, 10 skipped**
- Both exact CI commands run locally with no key: exit 0 (`18 skipped` / `22 skipped`)
- Workflow YAML parses (actionlint unavailable; PyYAML + manual review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
