### PR TITLE
fix: drop venue-typed source enums; align examples with market_reporting (#4175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-07-10
+
+### Changed
+
+- Loosen `source` typing and align examples with the API's masked source labels: the response `source` now returns `market_reporting` for non-government series (government labels like `EIA`/`opec.org` are unchanged). Model `source` fields remain a free `str` (no venue enum); test fixtures no longer use venue names such as `ICE`. See oilpriceapi-api#4175.
+
 ## [1.10.1] - 2026-07-03
 
 ### Changed

--- a/oilpriceapi/version.py
+++ b/oilpriceapi/version.py
@@ -5,6 +5,6 @@ Single source of truth for the SDK version string.
 Used in __init__.py, client.py, and async_client.py.
 """
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 SDK_VERSION = __version__
 SDK_NAME = "oilpriceapi-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oilpriceapi"
-version = "1.10.1"
+version = "1.10.2"
 description = "Official Python SDK for OilPriceAPI - Real-time and historical oil prices"
 authors = [
     {name = "OilPriceAPI", email = "support@oilpriceapi.com"}

--- a/tests/unit/test_commodities_resource.py
+++ b/tests/unit/test_commodities_resource.py
@@ -25,7 +25,7 @@ class TestCommoditiesResource:
             "unit": "barrel",
             "currency": "USD",
             "description": "North Sea Brent crude oil benchmark",
-            "source": "ICE",
+            "source": "market_reporting",
             "active": True
         }
 


### PR DESCRIPTION
## What & why

Part of the SDK-fleet sweep for oilpriceapi-api#4175. The API is switching masked source labels to `market_reporting` (government labels like `EIA`/`opec.org` unchanged). This aligns the Python SDK.

## Typing

No change needed to loosen — all model `source` fields are already free `str` (`models.py` lines 197/265/284/371, `Field(description=...)`). There is **no venue enum** in this SDK. So nothing breaks when the API starts returning `market_reporting`.

## Examples/fixtures fixed

- `tests/unit/test_commodities_resource.py`: fixture `"source": "ICE"` → `"source": "market_reporting"` (the only venue-as-source value in the repo).

README/docs contain no venue-as-source claims (verified).

## Version (unpublished)

- `1.10.1` → `1.10.2` in `pyproject.toml` and `oilpriceapi/version.py`
- CHANGELOG entry added
- **Not** published to PyPI — code + version bump only.

## Test/build

`pytest` is not installed in the sandbox, so the suite was not run here; the change is a single fixture-value swap (syntax validated, no `ICE` remaining). CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated commodity response behavior so non-government series use `market_reporting` as the source label.
  * Government source labels, such as `EIA` and `opec.org`, remain unchanged.
  * Clarified that the source value is a free-form string.
* **Release**
  * Updated the SDK to version 1.10.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->