### PR TITLE
chore: add dependabot config (pip + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration.
+#
+# Runtime deps in pyproject.toml are floor-pinned ranges (>=), so pip users
+# already resolve to the latest compatible releases; the value here is
+# keeping GitHub Actions pinned-by-tag workflows and the dev toolchain
+# (pytest/mypy/ruff/etc.) from drifting silently.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` (weekly pip + github-actions updates, Monday, 5-PR cap, labelled `dependencies`). The repo previously had no Dependabot coverage.

Context from the dependency review that prompted this:
- Runtime deps in `pyproject.toml` are floor-pinned ranges (`httpx>=0.24`, `pydantic>=2`, `python-dateutil>=2.8`) — PyPI users already resolve to current releases, nothing stale to bump.
- `pip-audit` on a fresh dev install: **no known vulnerabilities**.
- Weekly-health already runs `pip-audit --strict` (continue-on-error); Dependabot closes the gap for Actions pins and the dev toolchain.

No code changes; config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)