### PR TITLE
feat: publish executable Python snippet manifest

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -48,3 +48,14 @@ jobs:
             exit 0
           fi
           pytest tests/integration -m live --no-cov -v
+
+      - name: Run canonical success snippets against production
+        env:
+          OILPRICEAPI_KEY: ${{ secrets.OILPRICEAPI_TEST_KEY }}
+        run: |
+          if [ -z "$OILPRICEAPI_KEY" ]; then
+            echo "::warning::OILPRICEAPI_TEST_KEY not available; canonical snippet smoke skipped."
+            exit 0
+          fi
+          python examples/snippets/latest_price.py
+          python examples/snippets/history.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write # Required for trusted publishing
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -50,10 +51,21 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build 'jsonschema>=4.17,<4.24'
 
       - name: Build package
         run: python -m build
+
+      - name: Build signed snippet manifest
+        run: |
+          python scripts/generate_snippet_manifest.py \
+            --source-commit "$GITHUB_SHA" \
+            --output artifacts/snippets/oilpriceapi-python-snippets-v1.json
+
+      - name: Attach snippet manifest to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" artifacts/snippets/* --clobber
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +36,20 @@ jobs:
 
       - name: Run unit tests
         run: pytest tests/ --ignore=tests/integration --ignore=tests/contract -m 'not slow' --cov=oilpriceapi --cov-report=xml -v
+
+      - name: Build executable snippet manifest
+        run: |
+          python scripts/generate_snippet_manifest.py \
+            --source-commit "$GITHUB_SHA" \
+            --output artifacts/snippets/oilpriceapi-python-snippets-v1.json
+
+      - name: Upload snippet manifest
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: oilpriceapi-python-snippets-${{ github.sha }}
+          path: artifacts/snippets/
+          if-no-files-found: error
 
       - name: Upload coverage
         if: matrix.python-version == '3.12'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+artifacts/
 downloads/
 eggs/
 .eggs/
@@ -162,6 +163,8 @@ cython_debug/
 !pyproject.toml
 !setup.py
 !.env.example
+!schemas/*.json
+!examples/snippets/*.json
 
 # Keep example notebooks and GitHub Pages docs
 !examples/*.ipynb

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 
 **[Get a Free API Key](https://www.oilpriceapi.com/auth/signup?utm_source=python-sdk)** · **[Documentation](https://docs.oilpriceapi.com)** · **[Pricing](https://www.oilpriceapi.com/pricing?utm_source=python-sdk-limit)** · **[API Explorer](https://api.oilpriceapi.com/swagger)** · **[Quick start ↓](#-quick-start)**
 
+Canonical website and documentation snippets live in `examples/snippets/` and
+are executed in CI against deterministic fixtures. `scripts/generate_snippet_manifest.py`
+packages those exact files with runtime, package, response-shape, source-commit,
+and SHA-256 metadata. Release builds attach the manifest and checksum so
+downstream sites can pin reviewed SDK examples instead of copying code by hand.
+
 The official Python SDK for [OilPriceAPI](https://oilpriceapi.com), the commodity price API behind fintech dashboards, fleet & logistics tools, maritime compliance platforms and energy analytics products — serving **2M+ API requests every month**.
 
 > **📝 Documentation Status**: All code examples shown are tested and working. Technical indicators are available as of v1.10.0 (see [Technical Indicators](#technical-indicators-new-in-v1100)); see our [GitHub Issues](https://github.com/OilpriceAPI/python-sdk/issues) for the roadmap.

--- a/examples/snippets/_shared.py
+++ b/examples/snippets/_shared.py
@@ -1,0 +1,7 @@
+import os
+from typing import Optional
+
+
+def base_url() -> Optional[str]:
+    """Return the fixture override used by CI, or production when unset."""
+    return os.environ.get("OILPRICEAPI_BASE_URL")

--- a/examples/snippets/authentication_error.py
+++ b/examples/snippets/authentication_error.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import AuthenticationError, OilPriceAPI
+
+
+def run() -> Dict[str, Union[bool, int]]:
+    try:
+        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+            client.prices.get("BRENT_CRUDE_USD")
+    except AuthenticationError as error:
+        return {"handled": True, "status_code": error.status_code or 401}
+
+    raise RuntimeError("Expected the API to reject the credential")
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/examples/snippets/entitlement_error.py
+++ b/examples/snippets/entitlement_error.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import OilPriceAPI, OilPriceAPIError
+
+
+def run() -> Dict[str, Union[bool, int]]:
+    try:
+        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+            client.prices.get("BRENT_CRUDE_USD")
+    except OilPriceAPIError as error:
+        if error.status_code != 403:
+            raise
+        return {"handled": True, "status_code": error.status_code}
+
+    raise RuntimeError("Expected the API to reject the account entitlement")
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/examples/snippets/history.py
+++ b/examples/snippets/history.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import OilPriceAPI
+
+
+def run() -> Dict[str, Union[str, int]]:
+    with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+        history = client.historical.get(
+            commodity="BRENT_CRUDE_USD",
+            interval="daily",
+            per_page=5,
+        )
+
+    first = history.data[0]
+    return {
+        "commodity": first.commodity,
+        "count": len(history.data),
+        "value_type": type(first.value).__name__,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/examples/snippets/latest_price.py
+++ b/examples/snippets/latest_price.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import OilPriceAPI
+
+
+def run() -> Dict[str, Union[str, None]]:
+    with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+        price = client.prices.get("BRENT_CRUDE_USD")
+
+    return {
+        "commodity": price.commodity,
+        "currency": price.currency,
+        "value_type": type(price.value).__name__,
+        "timestamp_type": type(price.timestamp).__name__,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/examples/snippets/manifest-source.json
+++ b/examples/snippets/manifest-source.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.0.0",
+  "package": {
+    "name": "oilpriceapi",
+    "language": "python",
+    "minimum_runtime": "3.8"
+  },
+  "examples": [
+    {
+      "id": "python.latest-price",
+      "path": "examples/snippets/latest_price.py",
+      "kind": "success",
+      "endpoint": "GET /v1/prices/latest",
+      "docs_url": "https://docs.oilpriceapi.com/quick-start/python",
+      "expected_response_shape": {
+        "commodity": "string",
+        "currency": "string|null",
+        "value_type": "string",
+        "timestamp_type": "string"
+      }
+    },
+    {
+      "id": "python.history",
+      "path": "examples/snippets/history.py",
+      "kind": "success",
+      "endpoint": "GET /v1/prices/past_day",
+      "docs_url": "https://docs.oilpriceapi.com/quick-start/python",
+      "expected_response_shape": {
+        "commodity": "string",
+        "count": "integer",
+        "value_type": "string"
+      }
+    },
+    {
+      "id": "python.authentication-error",
+      "path": "examples/snippets/authentication_error.py",
+      "kind": "recovery",
+      "endpoint": "GET /v1/prices/latest",
+      "http_status": 401,
+      "docs_url": "https://docs.oilpriceapi.com/guides/authentication",
+      "expected_response_shape": {"handled": "boolean", "status_code": "integer"}
+    },
+    {
+      "id": "python.entitlement-error",
+      "path": "examples/snippets/entitlement_error.py",
+      "kind": "recovery",
+      "endpoint": "GET /v1/prices/latest",
+      "http_status": 403,
+      "docs_url": "https://docs.oilpriceapi.com/guides/error-codes",
+      "expected_response_shape": {"handled": "boolean", "status_code": "integer"}
+    },
+    {
+      "id": "python.rate-limit-error",
+      "path": "examples/snippets/rate_limit_error.py",
+      "kind": "recovery",
+      "endpoint": "GET /v1/prices/latest",
+      "http_status": 429,
+      "docs_url": "https://docs.oilpriceapi.com/guides/error-codes",
+      "expected_response_shape": {"handled": "boolean", "status_code": "integer"}
+    },
+    {
+      "id": "python.timeout-error",
+      "path": "examples/snippets/timeout_error.py",
+      "kind": "recovery",
+      "endpoint": "GET /v1/prices/latest",
+      "docs_url": "https://docs.oilpriceapi.com/guides/error-codes",
+      "expected_response_shape": {"handled": "boolean", "error_type": "string"}
+    }
+  ]
+}

--- a/examples/snippets/rate_limit_error.py
+++ b/examples/snippets/rate_limit_error.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import OilPriceAPI, RateLimitError
+
+
+def run() -> Dict[str, Union[bool, int]]:
+    try:
+        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+            client.prices.get("BRENT_CRUDE_USD")
+    except RateLimitError as error:
+        return {"handled": True, "status_code": error.status_code or 429}
+
+    raise RuntimeError("Expected the API to enforce its request limit")
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/examples/snippets/timeout_error.py
+++ b/examples/snippets/timeout_error.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import json
+from typing import Dict, Union
+
+from _shared import base_url
+
+from oilpriceapi import OilPriceAPI, TimeoutError
+
+
+def run() -> Dict[str, Union[bool, str]]:
+    try:
+        with OilPriceAPI(base_url=base_url(), max_retries=1, timeout=0.05) as client:
+            client.prices.get("BRENT_CRUDE_USD")
+    except TimeoutError:
+        return {"handled": True, "error_type": "TimeoutError"}
+
+    raise RuntimeError("Expected the request to time out")
+
+
+if __name__ == "__main__":
+    print(json.dumps(run(), sort_keys=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-timeout>=2.1.0",
+    "jsonschema>=4.17.0,<4.24",
     "black>=23.0.0",
     # Pin <3 defensively: mypy 2.x tightened defaults and rejected the old
     # python_version="3.8" config, which contributed to CI going red.

--- a/schemas/snippet-manifest.schema.json
+++ b/schemas/snippet-manifest.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.oilpriceapi.com/schemas/sdk-snippet-manifest-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package", "source_commit", "examples"],
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "source_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "language", "minimum_runtime"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "language": {"const": "python"},
+        "minimum_runtime": {"const": "3.8"}
+      }
+    },
+    "examples": {
+      "type": "array",
+      "minItems": 6,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "path", "kind", "endpoint", "docs_url", "expected_response_shape", "code", "sha256"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^python\\."},
+          "path": {"type": "string", "pattern": "^examples/snippets/.*\\.py$"},
+          "kind": {"enum": ["success", "recovery"]},
+          "endpoint": {"type": "string", "pattern": "^GET /v1/"},
+          "http_status": {"type": "integer", "enum": [401, 403, 429]},
+          "docs_url": {"type": "string", "pattern": "^https://docs\\.oilpriceapi\\.com/"},
+          "expected_response_shape": {"type": "object", "minProperties": 2, "additionalProperties": {"type": "string"}},
+          "code": {"type": "string", "minLength": 80},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/scripts/generate_snippet_manifest.py
+++ b/scripts/generate_snippet_manifest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = ROOT / "examples/snippets/manifest-source.json"
+SCHEMA_PATH = ROOT / "schemas/snippet-manifest.schema.json"
+VERSION_PATH = ROOT / "oilpriceapi/version.py"
+FORBIDDEN = (
+    re.compile(r"(?i)(api[_-]?key|token)\s*[:=]\s*['\"][A-Za-z0-9_-]{20,}"),
+    re.compile(r"your_api_key_here", re.IGNORECASE),
+)
+
+
+def package_version() -> str:
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', VERSION_PATH.read_text(), re.MULTILINE)
+    if not match:
+        raise ValueError("Unable to read package version")
+    return match.group(1)
+
+
+def default_commit() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+    ).strip()
+
+
+def build_manifest(source_commit: str) -> Dict[str, Any]:
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("source commit must be a full lowercase Git SHA")
+
+    source = json.loads(SOURCE_PATH.read_text())
+    examples = []
+    seen_ids = set()
+    for metadata in source["examples"]:
+        if metadata["id"] in seen_ids:
+            raise ValueError(f"duplicate example id: {metadata['id']}")
+        seen_ids.add(metadata["id"])
+
+        path = ROOT / metadata["path"]
+        code = path.read_text()
+        for pattern in FORBIDDEN:
+            if pattern.search(code):
+                raise ValueError(f"forbidden secret-like content in {metadata['path']}")
+
+        example = dict(metadata)
+        example["code"] = code
+        example["sha256"] = hashlib.sha256(code.encode("utf-8")).hexdigest()
+        examples.append(example)
+
+    manifest = {
+        "schema_version": source["schema_version"],
+        "package": {**source["package"], "version": package_version()},
+        "source_commit": source_commit,
+        "examples": examples,
+    }
+    schema = json.loads(SCHEMA_PATH.read_text())
+    Draft202012Validator(schema).validate(manifest)
+    return manifest
+
+
+def write_manifest(output: Path, source_commit: str) -> None:
+    manifest = build_manifest(source_commit)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    output.write_bytes(payload)
+    output.with_suffix(output.suffix + ".sha256").write_text(
+        f"{hashlib.sha256(payload).hexdigest()}  {output.name}\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the versioned SDK snippet manifest")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-commit", default=default_commit())
+    args = parser.parse_args()
+    write_manifest(args.output, args.source_commit)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_snippet_manifest.py
+++ b/tests/test_snippet_manifest.py
@@ -1,0 +1,132 @@
+import importlib.util
+import json
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict
+
+from jsonschema import Draft202012Validator
+
+from scripts.generate_snippet_manifest import build_manifest, write_manifest
+
+ROOT = Path(__file__).resolve().parents[1]
+SNIPPETS = ROOT / "examples/snippets"
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    scenario = "success"
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:
+        if self.scenario == "timeout":
+            time.sleep(0.2)
+            return
+
+        statuses = {"authentication": 401, "entitlement": 403, "rate_limit": 429}
+        status = statuses.get(self.scenario, 200)
+        if status != 200:
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            if status == 429:
+                self.send_header("Retry-After", "0")
+                self.send_header("X-RateLimit-Limit", "1")
+                self.send_header("X-RateLimit-Remaining", "0")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": self.scenario}).encode())
+            return
+
+        if "/v1/prices/latest" in self.path:
+            data: Dict[str, Any] = {
+                "status": "success",
+                "data": {
+                    "code": "BRENT_CRUDE_USD",
+                    "price": 72.5,
+                    "currency": "USD",
+                    "unit": "barrel",
+                    "created_at": "2026-01-15T12:00:00Z",
+                },
+            }
+        else:
+            data = {
+                "status": "success",
+                "data": {
+                    "prices": [
+                        {
+                            "code": "BRENT_CRUDE_USD",
+                            "price": 71.5,
+                            "currency": "USD",
+                            "unit": "barrel",
+                            "type": "spot_price",
+                            "created_at": "2026-01-14T12:00:00Z",
+                        }
+                    ]
+                },
+            }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("X-Total-Pages", "1")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+
+def load_snippet(name: str) -> ModuleType:
+    path = SNIPPETS / f"{name}.py"
+    sys.path.insert(0, str(SNIPPETS))
+    try:
+        spec = importlib.util.spec_from_file_location(f"snippet_{name}", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SNIPPETS))
+
+
+def test_manifest_validates_and_checksum_matches(tmp_path: Path) -> None:
+    commit = "a" * 40
+    output = tmp_path / "oilpriceapi-python-snippets-v1.json"
+    write_manifest(output, commit)
+    manifest = json.loads(output.read_text())
+    schema = json.loads((ROOT / "schemas/snippet-manifest.schema.json").read_text())
+    Draft202012Validator(schema).validate(manifest)
+
+    assert manifest == build_manifest(commit)
+    assert manifest["package"]["minimum_runtime"] == "3.8"
+    assert {
+        example["http_status"]
+        for example in manifest["examples"]
+        if "http_status" in example
+    } == {401, 403, 429}
+    assert output.with_suffix(".json.sha256").read_text().endswith(
+        "  oilpriceapi-python-snippets-v1.json\n"
+    )
+
+
+def test_exact_manifest_files_execute_against_fixtures(monkeypatch: Any) -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FixtureHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("OILPRICEAPI_KEY", "fixture-key")
+    monkeypatch.setenv("OILPRICEAPI_BASE_URL", f"http://127.0.0.1:{server.server_port}")
+
+    try:
+        cases = [
+            ("latest_price", "success", {"commodity": "BRENT_CRUDE_USD", "value_type": "float"}),
+            ("history", "success", {"commodity": "BRENT_CRUDE_USD", "count": 1}),
+            ("authentication_error", "authentication", {"handled": True, "status_code": 401}),
+            ("entitlement_error", "entitlement", {"handled": True, "status_code": 403}),
+            ("rate_limit_error", "rate_limit", {"handled": True, "status_code": 429}),
+            ("timeout_error", "timeout", {"handled": True, "error_type": "TimeoutError"}),
+        ]
+        for name, scenario, expected in cases:
+            FixtureHandler.scenario = scenario
+            result = load_snippet(name).run()
+            assert result.items() >= expected.items()
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Summary
- add six canonical Python examples for latest price, history, 401, 403, 429, and timeout recovery
- execute the exact files against deterministic fixtures and guard production success smokes
- generate a JSON Schema-validated, source-pinned manifest plus SHA-256 checksum
- upload per-commit CI artifacts and attach release assets
- restore Python 3.8 coverage for the documented runtime floor

## Verification
- 354 passed, 10 skipped; 59.36% coverage
- Ruff clean
- mypy clean across 45 source files
- manifest schema and checksum PASS
- all referenced docs URLs return 200

Closes #62
Related: OilpriceAPI/website-clean#1238