### PR TITLE
fix: make exported snippets standalone

### DIFF
--- a/examples/snippets/_shared.py
+++ b/examples/snippets/_shared.py
@@ -1,7 +1,0 @@
-import os
-from typing import Optional
-
-
-def base_url() -> Optional[str]:
-    """Return the fixture override used by CI, or production when unset."""
-    return os.environ.get("OILPRICEAPI_BASE_URL")

--- a/examples/snippets/authentication_error.py
+++ b/examples/snippets/authentication_error.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import AuthenticationError, OilPriceAPI
 
 
 def run() -> Dict[str, Union[bool, int]]:
     try:
-        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+        with OilPriceAPI(
+            api_key=os.environ["OILPRICEAPI_KEY"],
+            base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+            max_retries=1,
+        ) as client:
             client.prices.get("BRENT_CRUDE_USD")
     except AuthenticationError as error:
         return {"handled": True, "status_code": error.status_code or 401}

--- a/examples/snippets/entitlement_error.py
+++ b/examples/snippets/entitlement_error.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import OilPriceAPI, OilPriceAPIError
 
 
 def run() -> Dict[str, Union[bool, int]]:
     try:
-        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+        with OilPriceAPI(
+            api_key=os.environ["OILPRICEAPI_KEY"],
+            base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+            max_retries=1,
+        ) as client:
             client.prices.get("BRENT_CRUDE_USD")
     except OilPriceAPIError as error:
         if error.status_code != 403:

--- a/examples/snippets/history.py
+++ b/examples/snippets/history.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import OilPriceAPI
 
 
 def run() -> Dict[str, Union[str, int]]:
-    with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+    with OilPriceAPI(
+        api_key=os.environ["OILPRICEAPI_KEY"],
+        base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+        max_retries=1,
+    ) as client:
         history = client.historical.get(
             commodity="BRENT_CRUDE_USD",
             interval="daily",

--- a/examples/snippets/latest_price.py
+++ b/examples/snippets/latest_price.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import OilPriceAPI
 
 
 def run() -> Dict[str, Union[str, None]]:
-    with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+    with OilPriceAPI(
+        api_key=os.environ["OILPRICEAPI_KEY"],
+        base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+        max_retries=1,
+    ) as client:
         price = client.prices.get("BRENT_CRUDE_USD")
 
     return {

--- a/examples/snippets/rate_limit_error.py
+++ b/examples/snippets/rate_limit_error.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import OilPriceAPI, RateLimitError
 
 
 def run() -> Dict[str, Union[bool, int]]:
     try:
-        with OilPriceAPI(base_url=base_url(), max_retries=1) as client:
+        with OilPriceAPI(
+            api_key=os.environ["OILPRICEAPI_KEY"],
+            base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+            max_retries=1,
+        ) as client:
             client.prices.get("BRENT_CRUDE_USD")
     except RateLimitError as error:
         return {"handled": True, "status_code": error.status_code or 429}

--- a/examples/snippets/timeout_error.py
+++ b/examples/snippets/timeout_error.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 import json
+import os
 from typing import Dict, Union
-
-from _shared import base_url
 
 from oilpriceapi import OilPriceAPI, TimeoutError
 
 
 def run() -> Dict[str, Union[bool, str]]:
     try:
-        with OilPriceAPI(base_url=base_url(), max_retries=1, timeout=0.05) as client:
+        with OilPriceAPI(
+            api_key=os.environ["OILPRICEAPI_KEY"],
+            base_url=os.environ.get("OILPRICEAPI_BASE_URL"),
+            max_retries=1,
+            timeout=0.05,
+        ) as client:
             client.prices.get("BRENT_CRUDE_USD")
     except TimeoutError:
         return {"handled": True, "error_type": "TimeoutError"}

--- a/tests/test_snippet_manifest.py
+++ b/tests/test_snippet_manifest.py
@@ -102,6 +102,9 @@ def test_manifest_validates_and_checksum_matches(tmp_path: Path) -> None:
         for example in manifest["examples"]
         if "http_status" in example
     } == {401, 403, 429}
+    for example in manifest["examples"]:
+        assert "OILPRICEAPI_KEY" in example["code"]
+        assert "_shared" not in example["code"]
     assert output.with_suffix(".json.sha256").read_text().endswith(
         "  oilpriceapi-python-snippets-v1.json\n"
     )


### PR DESCRIPTION
## Summary
- remove the private `_shared` dependency from all six exported examples
- read `OILPRICEAPI_KEY` explicitly and keep `OILPRICEAPI_BASE_URL` as the CI-only override
- assert every manifest example is standalone and preserves the canonical environment variable

## Verification
- `ruff check examples/snippets tests/test_snippet_manifest.py`
- `pytest -q`: 358 passed, 58 skipped, 59.36% coverage

Follow-up to #63 and producer issue #62. Required before website consumer OilpriceAPI/website-clean#1238 is pinned.