### PR TITLE
Fix DataFrame currency preservation and pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Historical DataFrame helpers now accept a `per_page` value from 1 to 1000
+  and fetch all pages automatically. The `client.prices.to_dataframe(...)`
+  convenience path forwards the same option for date-range queries.
+
+### Fixed
+
+- Preserve each API record's currency and unit in current and historical
+  DataFrames instead of labeling a missing currency as USD.
+- Remove exact duplicate records introduced by overlapping page boundaries,
+  stop safely on empty pages with stale continuation metadata, and return a
+  stable schema for empty historical DataFrames.
+
 ## [1.11.0] - 2026-07-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ print(
 Use the raw first-request pattern when downstream logic requires the exact
 source and timestamp-field semantics from the API response.
 
+## Complete pandas DataFrames
+
+Install the optional pandas support, then request a historical DataFrame:
+
+```python
+df = client.historical.to_dataframe(
+    commodity="BRENT_CRUDE_USD",
+    start="2026-01-01",
+    end="2026-06-30",
+    per_page=500,
+)
+```
+
+`to_dataframe()` fetches every page automatically. `per_page` controls the
+request page size, not the total result size, and must be an integer from 1 to
+1000. The DataFrame preserves each API row's `currency` and `unit`; a missing
+currency remains missing rather than being labeled USD. Exact records repeated
+by an overlapping page boundary are returned once, while distinct records are
+retained. Empty results have a stable schema with a `date` index.
+
+The same `per_page` behavior applies to date-range queries through
+`client.prices.to_dataframe(...)`. See the
+[DataFrames and pagination guide](docs/DATAFRAMES.md) for the complete
+contract.
+
 ## Recovery
 
 The package exposes typed errors for the customer-recoverable boundaries:

--- a/docs/DATAFRAMES.md
+++ b/docs/DATAFRAMES.md
@@ -1,0 +1,80 @@
+# DataFrames and pagination
+
+The pandas helpers preserve the source context returned by the API and fetch
+complete result sets without requiring a manual page loop.
+
+Install the optional dependency:
+
+```bash
+python -m pip install "oilpriceapi[pandas]"
+```
+
+## Historical data
+
+```python
+from oilpriceapi import OilPriceAPI
+
+client = OilPriceAPI()
+df = client.historical.to_dataframe(
+    commodity="BRENT_CRUDE_USD",
+    start="2026-01-01",
+    end="2026-06-30",
+    interval="daily",
+    per_page=500,
+)
+```
+
+The historical DataFrame contract is:
+
+- Every page is fetched automatically until the API reports completion.
+- `per_page` is an integer from 1 to 1000 and defaults to 500.
+- `per_page` controls each request; it does not limit the total rows returned.
+- `currency` and `unit` are taken from each API record. A missing currency
+  remains null and is never converted to USD.
+- An exact record repeated on a later, overlapping page is emitted once.
+  Distinct records, including records sharing a timestamp, remain intact.
+- An empty page terminates pagination even if stale metadata says another page
+  exists.
+- The result is sorted by its `date` index. Empty results retain the columns
+  `commodity`, `value`, `currency`, `unit`, and `type_name`.
+
+The convenience resource uses the same pagination behavior:
+
+```python
+df = client.prices.to_dataframe(
+    commodity="EU_CARBON_EUR",
+    start="2026-01-01",
+    end="2026-06-30",
+    per_page=250,
+)
+```
+
+For model objects instead of pandas, use `client.historical.get_all(...)`.
+It accepts the same `per_page` range and automatically fetches every page.
+
+## Current prices
+
+Calling `client.prices.to_dataframe()` with no commodity returns all current
+prices and automatically follows the API's pagination headers:
+
+```python
+df = client.prices.to_dataframe(per_page=250)
+```
+
+Each row keeps the API-provided currency and unit. Exact records repeated on a
+later page are returned once.
+
+## Manual page control
+
+Use `client.historical.get(...)` when a single page is intentional:
+
+```python
+page = client.historical.get(
+    commodity="BRENT_CRUDE_USD",
+    page=2,
+    per_page=100,
+)
+```
+
+Use `client.historical.iter_pages(...)` to process complete results one page
+at a time without retaining the entire response in memory.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,12 +61,19 @@ df = client.prices.to_dataframe(
     commodity="BRENT_CRUDE_USD",
     start="2024-01-01",
     end="2024-12-31",
-    interval="daily"
+    interval="daily",
+    per_page=500
 )
 
 # Analyze trends
 print(df.describe())
 ```
+
+The DataFrame helper fetches every page and preserves the `currency` and
+`unit` returned for each record. `per_page` may be set from 1 to 1000 and
+controls request size rather than total results. See
+**[DataFrames and pagination →](DATAFRAMES.md)** for empty-result and page
+boundary behavior.
 
 **[Learn about historical endpoints →](https://docs.oilpriceapi.com/api-reference/historical)**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
 
 nav:
   - Home: index.md
+  - DataFrames and Pagination: DATAFRAMES.md
   - Performance Guide: PERFORMANCE_GUIDE.md
   - API Reference:
       - Client: reference/client.md

--- a/oilpriceapi/_pagination.py
+++ b/oilpriceapi/_pagination.py
@@ -1,0 +1,15 @@
+"""Shared pagination validation for public SDK helpers."""
+
+MIN_PAGE_SIZE = 1
+MAX_PAGE_SIZE = 1000
+
+
+def validate_page_size(per_page: int) -> int:
+    """Return a valid API page size or fail before making a request."""
+    if (
+        isinstance(per_page, bool)
+        or not isinstance(per_page, int)
+        or not MIN_PAGE_SIZE <= per_page <= MAX_PAGE_SIZE
+    ):
+        raise ValueError(f"per_page must be an integer between {MIN_PAGE_SIZE} and {MAX_PAGE_SIZE}")
+    return per_page

--- a/oilpriceapi/resources/historical.py
+++ b/oilpriceapi/resources/historical.py
@@ -5,9 +5,32 @@ Historical price data operations.
 """
 
 from datetime import date, datetime
-from typing import Generator, List, Optional, Union
+from typing import Generator, List, Optional, Set, Tuple, Union
 
+from .._pagination import validate_page_size
 from ..models import HistoricalPrice, HistoricalResponse, PaginationMeta
+
+DEFAULT_AUTO_PAGE_SIZE = 500
+HISTORICAL_DATAFRAME_COLUMNS = [
+    "date",
+    "commodity",
+    "value",
+    "currency",
+    "unit",
+    "type_name",
+]
+
+
+def _price_key(price: HistoricalPrice) -> Tuple[object, ...]:
+    """Identify an exact record so overlapping pages do not duplicate it."""
+    return (
+        price.date,
+        price.commodity,
+        price.value,
+        price.currency,
+        price.unit,
+        price.type_name,
+    )
 
 
 class HistoricalResource:
@@ -30,7 +53,7 @@ class HistoricalResource:
     def _get_optimal_endpoint(
         self,
         start_date: Optional[Union[str, date, datetime]],
-        end_date: Optional[Union[str, date, datetime]]
+        end_date: Optional[Union[str, date, datetime]],
     ) -> str:
         """Select optimal endpoint based on date range.
 
@@ -65,7 +88,7 @@ class HistoricalResource:
         self,
         start_date: Optional[Union[str, date, datetime]],
         end_date: Optional[Union[str, date, datetime]],
-        custom_timeout: Optional[float]
+        custom_timeout: Optional[float],
     ) -> Optional[float]:
         """Calculate appropriate timeout based on date range.
 
@@ -107,7 +130,7 @@ class HistoricalResource:
         page: int = 1,
         per_page: int = 100,
         type_name: str = "spot_price",
-        timeout: Optional[float] = None
+        timeout: Optional[float] = None,
     ) -> HistoricalResponse:
         """Get historical price data.
 
@@ -145,13 +168,15 @@ class HistoricalResource:
             ...     timeout=180  # 3 minutes
             ... )
         """
+        validated_per_page = validate_page_size(per_page)
+
         # Build parameters
         # CRITICAL: API expects 'by_code' not 'commodity' (Issue #XXX)
         params = {
             "by_code": commodity,  # Changed from 'commodity' to match API expectation
             "interval": interval,
             "page": page,
-            "per_page": min(per_page, 1000),  # Max 1000 per page
+            "per_page": validated_per_page,
             "by_type": type_name,
         }
 
@@ -170,15 +195,16 @@ class HistoricalResource:
         # Make request with optimal endpoint and timeout — use request_with_headers
         # so we can read X-Has-Next for reliable pagination detection
         response, headers = self.client.request_with_headers(
-            method="GET",
-            path=endpoint,
-            params=params,
-            timeout=request_timeout
+            method="GET", path=endpoint, params=params, timeout=request_timeout
         )
 
         # Parse response - handle nested structure
         # API returns: {"status": "success", "data": {"prices": [...]}}
-        if "data" in response and isinstance(response["data"], dict) and "prices" in response["data"]:
+        if (
+            "data" in response
+            and isinstance(response["data"], dict)
+            and "prices" in response["data"]
+        ):
             prices_data = response["data"]["prices"]
         elif "data" in response and isinstance(response["data"], list):
             prices_data = response["data"]
@@ -195,7 +221,7 @@ class HistoricalResource:
                     "commodity_name": price_data.get("code", price_data.get("commodity_name")),
                     "price": price_data.get("price"),
                     "currency": price_data.get("currency"),
-                    "unit_of_measure": price_data.get("unit", "barrel"),
+                    "unit_of_measure": price_data.get("unit"),
                     "type_name": price_data.get("type", "spot_price"),
                 }
                 prices.append(HistoricalPrice(**mapped_data))
@@ -203,9 +229,8 @@ class HistoricalResource:
         # Parse pagination metadata — prefer response headers over body
         # API uses X-Total-Pages (Kaminari-style) or X-Has-Next (custom)
         total_pages = int(headers.get("X-Total-Pages", 0))
-        has_next_header = (
-            str(headers.get("X-Has-Next", "")).lower() == "true"
-            or (total_pages > 0 and page < total_pages)
+        has_next_header = str(headers.get("X-Has-Next", "")).lower() == "true" or (
+            total_pages > 0 and page < total_pages
         )
 
         meta = None
@@ -213,7 +238,7 @@ class HistoricalResource:
             meta_data = response["meta"]
             meta = PaginationMeta(
                 page=meta_data.get("page", page),
-                per_page=meta_data.get("per_page", per_page),
+                per_page=meta_data.get("per_page", validated_per_page),
                 total=meta_data.get("total", len(prices)),
                 total_pages=meta_data.get("total_pages", 1),
                 has_next=meta_data.get("has_next", has_next_header),
@@ -223,18 +248,14 @@ class HistoricalResource:
             # Use X-Has-Next header for reliable pagination detection
             meta = PaginationMeta(
                 page=page,
-                per_page=per_page,
+                per_page=validated_per_page,
                 total=int(headers.get("X-Total", len(prices))),
                 total_pages=int(headers.get("X-Total-Pages", 1)),
                 has_next=has_next_header,
                 has_prev=page > 1,
             )
 
-        return HistoricalResponse(
-            success=True,
-            data=prices,
-            meta=meta
-        )
+        return HistoricalResponse(success=True, data=prices, meta=meta)
 
     def get_all(
         self,
@@ -242,7 +263,8 @@ class HistoricalResource:
         start_date: Optional[Union[str, date, datetime]] = None,
         end_date: Optional[Union[str, date, datetime]] = None,
         interval: str = "daily",
-        type_name: str = "spot_price"
+        type_name: str = "spot_price",
+        per_page: int = DEFAULT_AUTO_PAGE_SIZE,
     ) -> List[HistoricalPrice]:
         """Get all historical data (handles pagination automatically).
 
@@ -252,6 +274,7 @@ class HistoricalResource:
             end_date: End date for data range
             interval: Data interval
             type_name: Price type
+            per_page: Records per request, from 1 to 1000. Defaults to 500.
 
         Returns:
             List of all HistoricalPrice objects
@@ -264,7 +287,9 @@ class HistoricalResource:
             ... )
             >>> print(f"Total records: {len(all_data)}")
         """
-        all_prices = []
+        validated_per_page = validate_page_size(per_page)
+        all_prices: List[HistoricalPrice] = []
+        seen_previous_pages: Set[Tuple[object, ...]] = set()
         page = 1
 
         while True:
@@ -274,11 +299,20 @@ class HistoricalResource:
                 end_date=end_date,
                 interval=interval,
                 page=page,
-                per_page=500,  # API max is 500 per page
-                type_name=type_name
+                per_page=validated_per_page,
+                type_name=type_name,
             )
 
-            all_prices.extend(response.data)
+            if not response.data:
+                break
+
+            current_page_keys: Set[Tuple[object, ...]] = set()
+            for price in response.data:
+                key = _price_key(price)
+                if key not in seen_previous_pages:
+                    all_prices.append(price)
+                current_page_keys.add(key)
+            seen_previous_pages.update(current_page_keys)
 
             if not response.meta or not response.meta.has_next:
                 break
@@ -294,7 +328,7 @@ class HistoricalResource:
         end_date: Optional[Union[str, date, datetime]] = None,
         interval: str = "daily",
         per_page: int = 100,
-        type_name: str = "spot_price"
+        type_name: str = "spot_price",
     ) -> Generator[List[HistoricalPrice], None, None]:
         """Iterate through pages of historical data.
 
@@ -326,11 +360,13 @@ class HistoricalResource:
                 interval=interval,
                 page=page,
                 per_page=per_page,
-                type_name=type_name
+                type_name=type_name,
             )
 
             if response.data:
                 yield response.data
+            else:
+                break
 
             if not response.meta or not response.meta.has_next:
                 break
@@ -343,7 +379,8 @@ class HistoricalResource:
         start: Optional[Union[str, date, datetime]] = None,
         end: Optional[Union[str, date, datetime]] = None,
         interval: str = "daily",
-        type_name: str = "spot_price"
+        type_name: str = "spot_price",
+        per_page: int = DEFAULT_AUTO_PAGE_SIZE,
     ):
         """Get historical data as a pandas DataFrame.
 
@@ -355,6 +392,8 @@ class HistoricalResource:
             end: End date
             interval: Data interval
             type_name: Price type
+            per_page: Records per request, from 1 to 1000. All pages are
+                fetched automatically; defaults to 500.
 
         Returns:
             pandas DataFrame with historical prices
@@ -382,11 +421,15 @@ class HistoricalResource:
             start_date=start,
             end_date=end,
             interval=interval,
-            type_name=type_name
+            type_name=type_name,
+            per_page=per_page,
         )
 
         # Convert to DataFrame
-        df = pd.DataFrame([p.model_dump() for p in prices])
+        df = pd.DataFrame(
+            [p.model_dump() for p in prices],
+            columns=HISTORICAL_DATAFRAME_COLUMNS,
+        )
 
         # Set date as index
         if "date" in df.columns:

--- a/oilpriceapi/resources/prices.py
+++ b/oilpriceapi/resources/prices.py
@@ -3,11 +3,13 @@ Prices Resource
 
 Current price operations.
 """
+
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Tuple, Union
 
+from .._pagination import validate_page_size
 from ..models import Price
 
 
@@ -31,9 +33,7 @@ class PricesResource:
             >>> print(f"Brent: ${price.value:.2f}")
         """
         response = self.client.request(
-            method="GET",
-            path="/v1/prices/latest",
-            params={"by_code": commodity}
+            method="GET", path="/v1/prices/latest", params={"by_code": commodity}
         )
 
         # Parse response
@@ -42,16 +42,13 @@ class PricesResource:
         else:
             price_data = response
 
-        # Map API response to Price model
-        # Note: API should provide 'unit' field. If missing, we default to 'barrel'
-        # for backwards compatibility, but this may be incorrect for non-oil commodities
-        # (e.g., natural gas measured in MMBtu, electricity in MWh)
+        # Map API response to Price model without inventing source context.
         mapped_data = {
             "commodity": price_data.get("code", commodity),
             "value": price_data.get("price"),
-            # API responses are USD-denominated; default for backwards compatibility
-            # when the 'currency' field is absent from a minimal response.
-            "currency": price_data.get("currency", "USD"),
+            "currency": price_data.get("currency"),
+            # Retain the established oil-only fallback for legacy minimal
+            # responses; any unit actually supplied by the API wins.
             "unit": price_data.get("unit", "barrel"),
             "timestamp": price_data.get("created_at"),
         }
@@ -59,10 +56,7 @@ class PricesResource:
         return Price(**mapped_data)
 
     def get_multiple(
-        self,
-        commodities: List[str],
-        raise_on_error: bool = False,
-        return_failures: bool = False
+        self, commodities: List[str], raise_on_error: bool = False, return_failures: bool = False
     ) -> Union[List[Price], tuple[List[Price], List[tuple[str, str]]]]:
         """Get prices for multiple commodities.
 
@@ -129,14 +123,16 @@ class PricesResource:
             >>> all_prices = client.prices.get_all()
             >>> oil_prices = [p for p in all_prices if 'CRUDE' in p.commodity]
         """
+        validated_per_page = validate_page_size(per_page)
         all_prices: List[Price] = []
+        seen_previous_pages: Set[Tuple[object, ...]] = set()
         page = 1
 
         while True:
             body, headers = self.client.request_with_headers(
                 method="GET",
                 path="/v1/prices/all",
-                params={"page": page, "per_page": per_page},
+                params={"page": page, "per_page": validated_per_page},
             )
 
             # Parse response — /v1/prices/all returns nested:
@@ -151,18 +147,34 @@ class PricesResource:
                 prices_data = prices_data["prices"]
 
             # prices_data is now either a dict {CODE: {...}} or a list [{...}]
-            items = prices_data.values() if isinstance(prices_data, dict) else (prices_data if isinstance(prices_data, list) else [])
+            items = (
+                prices_data.values()
+                if isinstance(prices_data, dict)
+                else (prices_data if isinstance(prices_data, list) else [])
+            )
 
+            current_page_keys: Set[Tuple[object, ...]] = set()
             for price_data in items:
                 if isinstance(price_data, dict):
                     mapped = {
                         "commodity": price_data.get("code", ""),
                         "value": price_data.get("price"),
                         "currency": price_data.get("currency"),
-                        "unit": price_data.get("unit", "barrel"),
+                        "unit": price_data.get("unit"),
                         "timestamp": price_data.get("updated_at") or price_data.get("created_at"),
                     }
-                    all_prices.append(Price(**mapped))
+                    price = Price(**mapped)
+                    key = (
+                        price.timestamp,
+                        price.commodity,
+                        price.value,
+                        price.currency,
+                        price.unit,
+                    )
+                    if key not in seen_previous_pages:
+                        all_prices.append(price)
+                    current_page_keys.add(key)
+            seen_previous_pages.update(current_page_keys)
 
             # Check pagination header
             has_next = str(headers.get("X-Has-Next", "false")).lower() == "true"
@@ -192,10 +204,8 @@ class PricesResource:
             start: Start date for historical data
             end: End date for historical data
             interval: Data interval (minute, hourly, daily, weekly, monthly)
-            per_page: Records per page when fetching all current prices.
-                      Default 100 (matches API default). Only used when neither
-                      ``commodity`` nor ``commodities`` is specified and no date
-                      range is given. Auto-pagination fetches all pages.
+            per_page: Records per request, from 1 to 1000. Auto-pagination
+                      fetches every page for all-current and historical queries.
 
         Returns:
             pandas DataFrame with price data
@@ -219,6 +229,7 @@ class PricesResource:
         # If historical data requested, use historical endpoint
         if start or end:
             from .historical import HistoricalResource
+
             hist = HistoricalResource(self.client)
 
             if commodity:
@@ -226,7 +237,8 @@ class PricesResource:
                     commodity=commodity,
                     start=start,
                     end=end,
-                    interval=interval
+                    interval=interval,
+                    per_page=per_page,
                 )
             elif commodities:
                 dfs = []
@@ -235,7 +247,8 @@ class PricesResource:
                         commodity=comm,
                         start=start,
                         end=end,
-                        interval=interval
+                        interval=interval,
+                        per_page=per_page,
                     )
                     df_comm["commodity"] = comm
                     dfs.append(df_comm)

--- a/tests/fixtures/dataframe/empty-page.json.fixture
+++ b/tests/fixtures/dataframe/empty-page.json.fixture
@@ -1,0 +1,21 @@
+{
+  "body": {
+    "status": "success",
+    "data": {
+      "prices": []
+    },
+    "meta": {
+      "page": 1,
+      "per_page": 100,
+      "total": 0,
+      "total_pages": 2,
+      "has_next": true,
+      "has_prev": false
+    }
+  },
+  "headers": {
+    "X-Total": "0",
+    "X-Total-Pages": "2",
+    "X-Has-Next": "true"
+  }
+}

--- a/tests/fixtures/dataframe/historical-pages.json.fixture
+++ b/tests/fixtures/dataframe/historical-pages.json.fixture
@@ -1,0 +1,96 @@
+{
+  "pages": [
+    {
+      "body": {
+        "status": "success",
+        "data": {
+          "prices": [
+            {
+              "code": "BRENT_CRUDE_USD",
+              "price": 81.25,
+              "currency": "USD",
+              "unit": "barrel",
+              "created_at": "2026-07-20T00:00:00Z",
+              "type": "spot_price"
+            },
+            {
+              "code": "EU_CARBON_EUR",
+              "price": 72.4,
+              "currency": "EUR",
+              "unit": "tonne",
+              "created_at": "2026-07-20T01:00:00Z",
+              "type": "spot_price"
+            },
+            {
+              "code": "UK_NATURAL_GAS_GBP",
+              "price": 88.75,
+              "currency": "GBP",
+              "unit": "pence_per_therm",
+              "created_at": "2026-07-20T02:00:00Z",
+              "type": "spot_price"
+            }
+          ]
+        },
+        "meta": {
+          "page": 1,
+          "per_page": 3,
+          "total": 5,
+          "total_pages": 2,
+          "has_next": true,
+          "has_prev": false
+        }
+      },
+      "headers": {
+        "X-Total": "5",
+        "X-Total-Pages": "2",
+        "X-Has-Next": "true"
+      }
+    },
+    {
+      "body": {
+        "status": "success",
+        "data": {
+          "prices": [
+            {
+              "code": "UK_NATURAL_GAS_GBP",
+              "price": 88.75,
+              "currency": "GBP",
+              "unit": "pence_per_therm",
+              "created_at": "2026-07-20T02:00:00Z",
+              "type": "spot_price"
+            },
+            {
+              "code": "US_REFINERY_UTILIZATION",
+              "price": 91.2,
+              "currency": null,
+              "unit": "percent",
+              "created_at": "2026-07-20T03:00:00Z",
+              "type": "utilization"
+            },
+            {
+              "code": "ENERGY_PRICE_INDEX",
+              "price": 118.6,
+              "currency": null,
+              "unit": "index_points",
+              "created_at": "2026-07-20T04:00:00Z",
+              "type": "index"
+            }
+          ]
+        },
+        "meta": {
+          "page": 2,
+          "per_page": 3,
+          "total": 5,
+          "total_pages": 2,
+          "has_next": false,
+          "has_prev": true
+        }
+      },
+      "headers": {
+        "X-Total": "5",
+        "X-Total-Pages": "2",
+        "X-Has-Next": "false"
+      }
+    }
+  ]
+}

--- a/tests/unit/test_dataframe_pagination.py
+++ b/tests/unit/test_dataframe_pagination.py
@@ -1,0 +1,125 @@
+"""Regression tests for currency-safe, complete DataFrame pagination."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from oilpriceapi import OilPriceAPI
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "dataframe"
+HISTORICAL_COLUMNS = ["commodity", "value", "currency", "unit", "type_name"]
+
+
+def load_fixture(name: str):
+    """Load a production-shaped pagination fixture."""
+    return json.loads((FIXTURES / name).read_text())
+
+
+def make_response(page):
+    """Create an HTTP response mock from a fixture page."""
+    response = Mock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = page["body"]
+    response.headers = page["headers"]
+    return response
+
+
+@patch("httpx.Client.request")
+def test_historical_dataframe_preserves_context_and_page_boundaries(mock_request, api_key):
+    """Every unique API row survives pagination with its currency and unit intact."""
+    pytest.importorskip("pandas")
+    pages = load_fixture("historical-pages.json.fixture")["pages"]
+    mock_request.side_effect = [make_response(page) for page in pages]
+
+    client = OilPriceAPI(api_key=api_key)
+    dataframe = client.historical.to_dataframe(
+        commodity="ENERGY_DATA",
+        start="2026-07-20",
+        end="2026-07-21",
+        per_page=3,
+    )
+
+    assert len(dataframe) == 5
+    assert dataframe.index.is_unique
+    assert mock_request.call_count == 2
+    assert [call.kwargs["params"]["page"] for call in mock_request.call_args_list] == [1, 2]
+    assert all(call.kwargs["params"]["per_page"] == 3 for call in mock_request.call_args_list)
+
+    context = {row.commodity: (row.currency, row.unit) for row in dataframe.itertuples()}
+    assert context["BRENT_CRUDE_USD"] == ("USD", "barrel")
+    assert context["EU_CARBON_EUR"] == ("EUR", "tonne")
+    assert context["UK_NATURAL_GAS_GBP"] == ("GBP", "pence_per_therm")
+    assert context["US_REFINERY_UTILIZATION"][1] == "percent"
+    assert context["ENERGY_PRICE_INDEX"][1] == "index_points"
+    assert (
+        dataframe.loc[
+            dataframe["commodity"].isin(["US_REFINERY_UTILIZATION", "ENERGY_PRICE_INDEX"]),
+            "currency",
+        ]
+        .isna()
+        .all()
+    )
+    assert set(context) == {
+        "BRENT_CRUDE_USD",
+        "EU_CARBON_EUR",
+        "UK_NATURAL_GAS_GBP",
+        "US_REFINERY_UTILIZATION",
+        "ENERGY_PRICE_INDEX",
+    }
+
+
+@patch("httpx.Client.request")
+def test_historical_empty_page_stops_and_returns_stable_dataframe(mock_request, api_key):
+    """An empty page is terminal even when stale pagination metadata says otherwise."""
+    pytest.importorskip("pandas")
+    page = load_fixture("empty-page.json.fixture")
+    mock_request.return_value = make_response(page)
+
+    client = OilPriceAPI(api_key=api_key)
+    dataframe = client.historical.to_dataframe(
+        commodity="BRENT_CRUDE_USD",
+        per_page=100,
+    )
+
+    assert dataframe.empty
+    assert dataframe.index.name == "date"
+    assert list(dataframe.columns) == HISTORICAL_COLUMNS
+    mock_request.assert_called_once()
+
+
+@pytest.mark.parametrize("per_page", [0, -1, 1001, 1.5, True])
+def test_historical_rejects_page_sizes_outside_api_limits(api_key, per_page):
+    """Invalid page sizes fail before any network request is made."""
+    client = OilPriceAPI(api_key=api_key)
+
+    with patch.object(client, "request_with_headers") as request:
+        with pytest.raises(ValueError, match="per_page must be an integer between 1 and 1000"):
+            client.historical.get("BRENT_CRUDE_USD", per_page=per_page)
+        request.assert_not_called()
+
+
+@patch("oilpriceapi.resources.historical.HistoricalResource")
+def test_prices_dataframe_forwards_page_size_to_historical(mock_historical, api_key):
+    """The convenience DataFrame path honors page size for date-range queries."""
+    pytest.importorskip("pandas")
+    resource = mock_historical.return_value
+    resource.to_dataframe.return_value = Mock()
+
+    client = OilPriceAPI(api_key=api_key)
+    client.prices.to_dataframe(
+        commodity="BRENT_CRUDE_USD",
+        start="2026-07-01",
+        end="2026-07-20",
+        per_page=250,
+    )
+
+    resource.to_dataframe.assert_called_once_with(
+        commodity="BRENT_CRUDE_USD",
+        start="2026-07-01",
+        end="2026-07-20",
+        interval="daily",
+        per_page=250,
+    )

--- a/tests/unit/test_prices_resource.py
+++ b/tests/unit/test_prices_resource.py
@@ -12,7 +12,7 @@ from oilpriceapi.exceptions import DataNotFoundError
 class TestPricesResource:
     """Test PricesResource class."""
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_single_price(self, mock_request, api_key, mock_price_response):
         """Test getting a single commodity price."""
         mock_response = Mock()
@@ -35,7 +35,7 @@ class TestPricesResource:
         assert "by_code" in call_kwargs["params"]
         assert call_kwargs["params"]["by_code"] == "BRENT_CRUDE_USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_multiple_prices(self, mock_request, api_key, mock_price_response):
         """Test getting multiple commodity prices."""
         # Mock responses for each commodity
@@ -50,8 +50,8 @@ class TestPricesResource:
                         "currency": "USD",
                         "created_at": "2024-01-15T10:00:00Z",
                         "type": "spot_price",
-                    }
-                }
+                    },
+                },
             ),
             Mock(
                 status_code=200,
@@ -63,8 +63,8 @@ class TestPricesResource:
                         "currency": "USD",
                         "created_at": "2024-01-15T10:00:00Z",
                         "type": "spot_price",
-                    }
-                }
+                    },
+                },
             ),
         ]
         mock_request.side_effect = responses
@@ -79,7 +79,7 @@ class TestPricesResource:
         assert prices[1].value == 70.25
         assert mock_request.call_count == 2
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_multiple_prices_with_failures(self, mock_request, api_key):
         """Test get_multiple skips failed commodities."""
         # First succeeds, second fails, third succeeds
@@ -94,8 +94,8 @@ class TestPricesResource:
                         "currency": "USD",
                         "created_at": "2024-01-15T10:00:00Z",
                         "type": "spot_price",
-                    }
-                }
+                    },
+                },
             ),
             Mock(status_code=404, json=lambda: {"error": "Not found"}),
             Mock(
@@ -108,25 +108,21 @@ class TestPricesResource:
                         "currency": "USD",
                         "created_at": "2024-01-15T10:00:00Z",
                         "type": "spot_price",
-                    }
-                }
+                    },
+                },
             ),
         ]
         mock_request.side_effect = responses
 
         client = OilPriceAPI(api_key=api_key)
-        prices = client.prices.get_multiple([
-            "BRENT_CRUDE_USD",
-            "INVALID_CODE",
-            "NATURAL_GAS_USD"
-        ])
+        prices = client.prices.get_multiple(["BRENT_CRUDE_USD", "INVALID_CODE", "NATURAL_GAS_USD"])
 
         # Should only return 2 prices (skips the failed one)
         assert len(prices) == 2
         assert prices[0].commodity == "BRENT_CRUDE_USD"
         assert prices[1].commodity == "NATURAL_GAS_USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_price_with_alternate_response_format(self, mock_request, api_key):
         """Test handling response without nested data key."""
         mock_response = Mock()
@@ -147,7 +143,7 @@ class TestPricesResource:
         assert price.commodity == "BRENT_CRUDE_USD"
         assert price.value == 75.50
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_to_dataframe_current_single(self, mock_request, api_key, mock_price_response):
         """Test converting single current price to DataFrame."""
         pytest.importorskip("pandas")  # Skip if pandas not installed
@@ -166,12 +162,13 @@ class TestPricesResource:
         assert "value" in df.columns
         assert df["commodity"].iloc[0] == "BRENT_CRUDE_USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_to_dataframe_without_pandas(self, mock_request, api_key, monkeypatch):
         """Test to_dataframe raises error when pandas not available."""
         # Hide pandas
         import sys
-        monkeypatch.setitem(sys.modules, 'pandas', None)
+
+        monkeypatch.setitem(sys.modules, "pandas", None)
 
         client = OilPriceAPI(api_key=api_key)
 
@@ -184,10 +181,11 @@ class TestPricesResource:
 class TestGetAllPagination:
     """Test get_all auto-pagination via X-Has-Next header."""
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_all_single_page(self, mock_request, api_key):
         """Test get_all with a single page (X-Has-Next: false)."""
         import httpx
+
         mock_response = Mock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -218,7 +216,7 @@ class TestGetAllPagination:
         assert len(prices) == 2
         assert mock_request.call_count == 1
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_all_multi_page(self, mock_request, api_key):
         """Test get_all fetches all pages when X-Has-Next is true."""
         import httpx
@@ -262,10 +260,11 @@ class TestGetAllPagination:
         assert prices[0].commodity == "BRENT_CRUDE_USD"
         assert prices[1].commodity == "WTI_USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_all_preserves_currency(self, mock_request, api_key):
         """Bug 1: get_all must preserve each record's currency field."""
         import httpx
+
         mock_response = Mock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -305,11 +304,12 @@ class TestGetAllPagination:
         assert by_code["NATURAL_GAS_GBP"].currency == "GBP"
         assert by_code["BRENT_CRUDE_USD"].currency == "USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_to_dataframe_currency_column(self, mock_request, api_key):
         """Bug 1: to_dataframe() currency column must reflect each commodity's currency."""
         pytest.importorskip("pandas")
         import httpx
+
         mock_response = Mock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -342,11 +342,12 @@ class TestGetAllPagination:
         assert currencies["EU_CARBON_EUR"] == "EUR"
         assert currencies["BRENT_CRUDE_USD"] == "USD"
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_to_dataframe_per_page_parameter(self, mock_request, api_key):
         """Bug 2: to_dataframe() per_page parameter is forwarded to get_all."""
         pytest.importorskip("pandas")
         import httpx
+
         mock_response = Mock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -375,7 +376,7 @@ class TestGetAllPagination:
 class TestPricesResourceErrorHandling:
     """Test error handling in prices resource."""
 
-    @patch('httpx.Client.request')
+    @patch("httpx.Client.request")
     def test_get_price_not_found(self, mock_request, api_key, mock_404_response):
         """Test handling commodity not found."""
         mock_request.return_value = mock_404_response
@@ -389,9 +390,9 @@ class TestPricesResourceErrorHandling:
         assert error.status_code == 404
         assert "not found" in str(error).lower()
 
-    @patch('httpx.Client.request')
-    def test_get_price_handles_missing_fields(self, mock_request, api_key):
-        """Test handling response with missing optional fields."""
+    @patch("httpx.Client.request")
+    def test_get_price_does_not_invent_missing_currency(self, mock_request, api_key):
+        """A missing currency remains unknown instead of being labeled USD."""
         mock_response = Mock()
         mock_response.status_code = 200
         # Minimal response
@@ -400,8 +401,9 @@ class TestPricesResourceErrorHandling:
             "data": {
                 "code": "TEST",
                 "price": 100.0,
+                "unit": "index_points",
                 "created_at": "2024-01-15T10:00:00Z",
-            }
+            },
         }
         mock_request.return_value = mock_response
 
@@ -410,6 +412,5 @@ class TestPricesResourceErrorHandling:
 
         assert price.commodity == "TEST"
         assert price.value == 100.0
-        # Should have defaults for missing fields
-        assert price.currency == "USD"
-        assert price.unit == "barrel"
+        assert price.currency is None
+        assert price.unit == "index_points"


### PR DESCRIPTION
Closes #70.

## What changed
- preserve API-provided currency and unit in current and historical DataFrames
- validate explicit page sizes from 1 to 1000 and forward them through convenience helpers
- auto-fetch all historical pages, remove exact cross-page duplicates, and terminate safely on empty pages
- return a stable empty historical DataFrame schema
- add production-shaped fixtures for USD, EUR, GBP/pence, percent, index, empty, and multi-page responses
- document the DataFrame pagination contract in README, API docs, and changelog

## Verification
- 397 tests passed; 64.54% coverage
- `ruff check oilpriceapi/`
- `mypy oilpriceapi/ --ignore-missing-imports`
- package sdist/wheel build and isolated wheel smoke
- MkDocs Pages-equivalent build includes the new guide

No package publish is included or requested. Merging is expected to trigger only the repository test/live/Pages workflows.