### PR TITLE
Validate dates and add live commodity-code guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add sync and async `client.commodities.search(...)`, backed by the current
+  API catalog rather than a bundled commodity-code list.
+- Expose bounded, credential-redacted `suggestions` and `invalid_codes` from
+  nested invalid-code error responses.
+
 ### Changed
 
+- Date-bearing resources now reject malformed or impossible `YYYY-MM-DD`
+  strings locally while leaving well-formed range semantics to the API.
 - Historical DataFrame helpers now accept a `per_page` value from 1 to 1000
   and fetch all pages automatically. The `client.prices.to_dataframe(...)`
   convenience path forwards the same option for date-range queries.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ The same `per_page` behavior applies to date-range queries through
 [DataFrames and pagination guide](docs/DATAFRAMES.md) for the complete
 contract.
 
+## Dates and Commodity Codes
+
+Date strings must be real calendar dates in exact `YYYY-MM-DD` form. Malformed
+values are rejected before an API request, while well-formed ranges are still
+validated authoritatively by the server.
+
+Search the current API catalog instead of maintaining a local code list:
+
+```python
+matches = client.commodities.search("brent crude", limit=5)
+print([commodity["code"] for commodity in matches])
+```
+
+Invalid-code API responses expose sanitized recovery values through
+`error.suggestions` and `error.invalid_codes`. See the
+[dates and commodity-code guide](docs/CODE_GUIDANCE.md) for sync/async examples
+and failure behavior.
+
 ## Recovery
 
 The package exposes typed errors for the customer-recoverable boundaries:
@@ -199,10 +217,10 @@ except OilPriceAPIError as error:
 
 All non-2xx responses share the same `OilPriceAPIError` attributes, including
 `status_code`, `code`, `request_id`, plan/feature recovery fields, retry
-metadata, sanitized response `headers`, `raw_body`, and `raw_text`. Canonical
-nested and legacy flat API error envelopes are normalized into that contract.
-Transport failures use `NetworkError`; timeouts remain the more specific
-`TimeoutError`.
+metadata, commodity `suggestions` and `invalid_codes`, sanitized response
+`headers`, `raw_body`, and `raw_text`. Canonical nested, fail/data, and legacy
+flat API error envelopes are normalized into that contract. Transport failures
+use `NetworkError`; timeouts remain the more specific `TimeoutError`.
 
 Executable recovery examples cover 401, 403, 429, and timeout responses under
 [`examples/snippets/`](examples/snippets/). Empty or malformed successful

--- a/docs/CODE_GUIDANCE.md
+++ b/docs/CODE_GUIDANCE.md
@@ -1,0 +1,69 @@
+# Dates and commodity-code guidance
+
+## Strict date syntax
+
+SDK methods that accept dates validate each supplied value before sending a
+request. Strings must be a real calendar date in exact `YYYY-MM-DD` form.
+`datetime.date` and `datetime.datetime` values are also accepted and normalized
+to that form.
+
+```python
+from datetime import date
+
+client.historical.get(
+    "BRENT_CRUDE_USD",
+    start_date=date(2026, 1, 1),
+    end_date="2026-01-31",
+)
+```
+
+Malformed values such as `2026-01-010`, `2026-1-10`, impossible calendar
+dates, empty strings, and datetime strings are rejected locally with
+`ValueError`; no API request is made. A range whose individual dates are valid
+but whose ordering or business meaning is invalid is still sent to the API so
+the server remains the authority for range semantics.
+
+## Search the current catalog
+
+Use `commodities.search()` when a code is unknown. Each search fetches the
+current API catalog and ranks matches across code, name, category, description,
+currency, unit, and source. The SDK does not bundle a hand-maintained code list.
+
+```python
+matches = client.commodities.search("brent crude", limit=5)
+for commodity in matches:
+    print(commodity["code"], commodity.get("name"))
+```
+
+The async client provides the same behavior:
+
+```python
+matches = await client.commodities.search("natural gas")
+```
+
+No match or an empty catalog returns `[]`. Authentication, network, timeout,
+and other API failures are not converted into an empty result; their existing
+typed SDK exceptions propagate so callers can distinguish failure from “no
+matches.”
+
+## Recover from an invalid code
+
+When the API includes commodity suggestions in an error response, the SDK
+exposes bounded string values on `error.suggestions`. Invalid submitted codes
+are available on `error.invalid_codes`.
+
+```python
+from oilpriceapi import OilPriceAPIError
+
+try:
+    client.prices.get("BRENNT")
+except OilPriceAPIError as error:
+    if error.code == "invalid_code" and error.suggestions:
+        print("Try one of:", ", ".join(error.suggestions))
+    else:
+        raise
+```
+
+The response parser ignores unexpected non-string suggestion values, limits
+the number and length of values retained, and applies the same credential
+redaction used for other error diagnostics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,6 +77,10 @@ boundary behavior.
 
 **[Learn about historical endpoints →](https://docs.oilpriceapi.com/api-reference/historical)**
 
+Date strings use strict `YYYY-MM-DD` syntax and are checked before a request.
+See **[Dates and commodity codes →](CODE_GUIDANCE.md)** for validation and
+recovery behavior.
+
 ### Technical Analysis
 
 Built-in technical indicators for trading strategies:
@@ -134,24 +138,17 @@ Embed live commodity price widgets and charts in your applications.
 
 **[Explore integration guides →](https://docs.oilpriceapi.com/integrations)**
 
-## 📊 Available Commodities
+## 📊 Find Commodity Codes
 
-### Crude Oil
-- **Brent Crude** (`BRENT_CRUDE_USD`) - International benchmark
-- **WTI** (`WTI_USD`) - US benchmark
-- **Dubai Crude** (`DUBAI_CRUDE_USD`) - Middle East benchmark
+Search the current API catalog so an integration does not depend on a stale
+code list:
 
-### Natural Gas
-- **Natural Gas** (`NATURAL_GAS_USD`) - Henry Hub spot price
-- **LNG** (`LNG_USD`) - Liquefied natural gas
+```python
+matches = client.commodities.search("brent crude", limit=5)
+print([commodity["code"] for commodity in matches])
+```
 
-### Refined Products
-- **Diesel** (`DIESEL_USD`)
-- **Gasoline** (`GASOLINE_USD`)
-- **Heating Oil** (`HEATING_OIL_USD`)
-- **Jet Fuel** (`JET_FUEL_USD`)
-
-**[View complete commodity list →](https://docs.oilpriceapi.com/commodities)**
+**[View dates and commodity-code guidance →](CODE_GUIDANCE.md)**
 
 ## 🔧 Advanced Configuration
 
@@ -202,6 +199,8 @@ except RateLimitError as error:
 except DataNotFoundError:
     print("Commodity not found")
 except OilPriceAPIError as error:
+    if error.code == "invalid_code" and error.suggestions:
+        print("Try one of:", ", ".join(error.suggestions))
     if error.request_id:
         print("Support request ID:", error.request_id)
     if error.remediation_url:
@@ -210,8 +209,9 @@ except OilPriceAPIError as error:
 ```
 
 Every non-2xx response uses this shared typed contract. `status_code`, `code`,
-plan or feature requirements, retry metadata, sanitized response headers, and
-raw diagnostics remain available without exposing the configured API key.
+commodity suggestions, plan or feature requirements, retry metadata, sanitized
+response headers, and raw diagnostics remain available without exposing the
+configured API key.
 
 ## 💰 Pricing & Plans
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Dates and Commodity Codes: CODE_GUIDANCE.md
   - DataFrames and Pagination: DATAFRAMES.md
   - Synthetic Monitoring: SYNTHETIC_MONITORING.md
   - Release Process: RELEASE_PROCESS.md

--- a/oilpriceapi/async_client.py
+++ b/oilpriceapi/async_client.py
@@ -42,6 +42,7 @@ from .exceptions import (
     error_from_response,
 )
 from .models import HistoricalPrice, HistoricalResponse, MarketBrief, Price
+from .resource_validators import format_date
 from .retry import RetryStrategy
 
 
@@ -464,10 +465,10 @@ class AsyncHistoricalResource:
             "by_type": type_name,
         }
 
-        if start_date:
-            params["start_date"] = start_date
-        if end_date:
-            params["end_date"] = end_date
+        if start_date is not None:
+            params["start_date"] = format_date(start_date)
+        if end_date is not None:
+            params["end_date"] = format_date(end_date)
 
         response = await self.client.request(
             method="GET", path="/v1/prices/past_year", params=params

--- a/oilpriceapi/async_resources.py
+++ b/oilpriceapi/async_resources.py
@@ -10,7 +10,13 @@ from ._subscriptions_common import (
 )
 from .exceptions import ValidationError
 from .models import DieselPrice, DieselStationsResponse, PriceAlert, Subscription, SubscriptionEvent
-from .resource_validators import VALID_OPERATORS, format_date, normalize_api_number
+from .resource_validators import (
+    VALID_OPERATORS,
+    extract_commodity_catalog,
+    format_date,
+    normalize_api_number,
+    search_commodity_catalog,
+)
 from .resources._futures_slug import normalize_futures_slug
 from .resources.subscriptions import SubscriptionEventsPage
 
@@ -286,15 +292,18 @@ class AsyncCommoditiesResource:
 
     async def list(self) -> List[Dict[str, Any]]:
         response = await self.client.request(method="GET", path="/v1/commodities")
-        if "data" in response:
-            return response["data"]
-        return response
+        return extract_commodity_catalog(response)
 
     async def get(self, code: str) -> Dict[str, Any]:
         response = await self.client.request(method="GET", path=f"/v1/commodities/{code}")
         if "data" in response:
             return response["data"]
         return response
+
+    async def search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Search the API's current catalog without a bundled code list."""
+        catalog = await self.list()
+        return search_commodity_catalog(catalog, query=query, limit=limit)
 
     async def categories(self) -> Dict[str, List[Dict[str, Any]]]:
         response = await self.client.request(method="GET", path="/v1/commodities/categories")
@@ -334,9 +343,9 @@ class AsyncFuturesResource:
     ) -> List[Dict[str, Any]]:
         slug = normalize_futures_slug(contract)
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = format_date(end_date)
         response = await self.client.request(
             method="GET", path=f"/v1/futures/{slug}/historical", params=params
@@ -348,8 +357,8 @@ class AsyncFuturesResource:
     async def ohlc(self, contract: str, date: Optional[str] = None) -> Dict[str, Any]:
         slug = normalize_futures_slug(contract)
         params = {}
-        if date:
-            params["date"] = date
+        if date is not None:
+            params["date"] = format_date(date)
         response = await self.client.request(
             method="GET", path=f"/v1/futures/{slug}/ohlc", params=params
         )
@@ -442,9 +451,9 @@ class AsyncStorageResource:
         end_date: Optional[Union[str, date, datetime]] = None
     ) -> List[Dict[str, Any]]:
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = format_date(end_date)
         response = await self.client.request(
             method="GET", path=f"/v1/storage/{code}/history", params=params
@@ -476,9 +485,9 @@ class AsyncRigCountsResource:
         end_date: Optional[Union[str, date, datetime]] = None
     ) -> List[Dict[str, Any]]:
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = format_date(end_date)
         response = await self.client.request(
             method="GET", path="/v1/rig-counts/historical", params=params
@@ -541,9 +550,9 @@ class AsyncBunkerFuelsResource:
         end_date: Optional[Union[str, date, datetime]] = None
     ) -> List[Dict[str, Any]]:
         params: Dict[str, Any] = {"port": port, "fuel_type": fuel_type}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = format_date(end_date)
         response = await self.client.request(
             method="GET", path="/v1/bunker-fuels/historical", params=params
@@ -806,9 +815,9 @@ class AsyncWellProductionResource:
         **params,
     ) -> Dict[str, Any]:
         if start_date is not None:
-            params["start_date"] = start_date
+            params["start_date"] = format_date(start_date)
         if end_date is not None:
-            params["end_date"] = end_date
+            params["end_date"] = format_date(end_date)
         response = await self.client.request(
             method="GET", path=f"/v1/well-production/states/{code}", params=params
         )
@@ -857,8 +866,8 @@ class AsyncWellProductionResource:
     ) -> Dict[str, Any]:
         filters = {
             "state": state,
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": format_date(start_date) if start_date is not None else None,
+            "end_date": format_date(end_date) if end_date is not None else None,
             "operator": operator,
             "formation": formation,
             "lat": lat,
@@ -886,8 +895,8 @@ class AsyncWellProductionResource:
     ) -> Dict[str, Any]:
         filters = {
             "state": state,
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": format_date(start_date) if start_date is not None else None,
+            "end_date": format_date(end_date) if end_date is not None else None,
             "lat": lat,
             "lng": lng,
             "radius_miles": radius_miles,

--- a/oilpriceapi/exceptions.py
+++ b/oilpriceapi/exceptions.py
@@ -125,6 +125,24 @@ def _number(value: Any) -> Any:
     return int(number) if number.is_integer() else number
 
 
+def _string_list(value: Any, *, limit: int = 20, max_length: int = 128) -> List[str]:
+    """Keep only bounded strings from untrusted error-response list fields."""
+    if not isinstance(value, (list, tuple)):
+        return []
+
+    result: List[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        normalized = item.strip()
+        if not normalized:
+            continue
+        result.append(normalized[:max_length])
+        if len(result) >= limit:
+            break
+    return result
+
+
 def _parse_reset_time(value: Any) -> Optional[datetime]:
     if value is None:
         return None
@@ -158,6 +176,8 @@ class OilPriceAPIError(Exception):
         raw_body: Any = None,
         raw_text: str = "",
         headers: Optional[Mapping[str, str]] = None,
+        suggestions: Optional[List[str]] = None,
+        invalid_codes: Optional[List[str]] = None,
     ):
         super().__init__(message)
         self.message = message
@@ -175,6 +195,8 @@ class OilPriceAPIError(Exception):
         self.raw_body = raw_body if raw_body is not None else response
         self.raw_text = raw_text
         self.headers = dict(headers or {})
+        self.suggestions = list(suggestions or [])
+        self.invalid_codes = list(invalid_codes or [])
         # Retain the historical attribute while exposing raw_body for all shapes.
         self.response = (
             response
@@ -392,12 +414,22 @@ def error_from_response(
     raw_body, raw_text = _response_body(response, secrets)
     headers = _response_headers(response, secrets)
     payload = _mapping(raw_body)
-    nested_error = _mapping(payload.get("error"))
-    primary = nested_error or payload
-    details = _mapping(primary.get("details")) or _mapping(payload.get("details"))
-    sources = (primary, details, payload)
+    nested_data = _mapping(payload.get("data"))
+    nested_error = _mapping(payload.get("error")) or _mapping(nested_data.get("error"))
+    primary = nested_error or nested_data or payload
+    details = (
+        _mapping(primary.get("details"))
+        or _mapping(nested_data.get("details"))
+        or _mapping(payload.get("details"))
+    )
+    sources = (primary, details, nested_data, payload)
 
-    legacy_error = payload.get("error")
+    nested_data_error = nested_data.get("error")
+    legacy_error = (
+        nested_data_error
+        if nested_data_error is not None
+        else payload.get("error")
+    )
     message_value = _first_value(sources, "message", "detail", "title")
     if message_value is None and isinstance(legacy_error, str):
         message_value = legacy_error
@@ -405,6 +437,8 @@ def error_from_response(
     message = str(message_value or raw_text.strip() or f"HTTP {status_code} error")
 
     code_value = _first_value(sources, "code", "error_code", "type")
+    if code_value is None and isinstance(nested_data_error, str):
+        code_value = nested_data_error
     request_id_value = _first_value(
         sources,
         "request_id",
@@ -438,6 +472,16 @@ def error_from_response(
     if remaining is not None:
         retry_metadata.setdefault("remaining", remaining)
 
+    suggestions = _string_list(
+        _first_value(
+            sources,
+            "suggestions",
+            "did_you_mean",
+            "valid_commodities",
+        )
+    )
+    invalid_codes = _string_list(_first_value(sources, "invalid_codes"))
+
     raw_response = raw_body if isinstance(raw_body, dict) else None
     common: Dict[str, Any] = {
         "response": raw_response,
@@ -466,6 +510,8 @@ def error_from_response(
         "raw_body": raw_body,
         "raw_text": raw_text,
         "headers": headers,
+        "suggestions": suggestions,
+        "invalid_codes": invalid_codes,
     }
 
     if status_code == 400:
@@ -477,7 +523,12 @@ def error_from_response(
     if status_code == 403:
         return PermissionDeniedError(message, **common)
     if status_code == 404:
-        return DataNotFoundError(message, commodity=commodity, **common)
+        return DataNotFoundError(
+            message,
+            commodity=commodity,
+            valid_commodities=suggestions or None,
+            **common,
+        )
     if status_code == 422:
         return ValidationError(
             message,

--- a/oilpriceapi/resource_validators.py
+++ b/oilpriceapi/resource_validators.py
@@ -8,8 +8,9 @@ async resources is the HTTP call (sync vs await).
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime
-from typing import Union
+from typing import Any, Dict, Iterable, List, Mapping, Union
 
 # ---------------------------------------------------------------------------
 # Alert operators
@@ -28,31 +29,138 @@ VALID_OPERATORS = [
 # Date formatting
 # ---------------------------------------------------------------------------
 
+_ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
 def format_date(date_input: Union[str, date, datetime]) -> str:
-    """Normalise a date/datetime/str value to an ISO-8601 date string.
+    """Normalize a date/datetime/str value to a strict ISO-8601 date.
 
     Used by futures, storage, rig_counts, and bunker_fuels resources to
     convert the flexible ``start_date`` / ``end_date`` parameters before
     passing them as query-string values.
 
     Args:
-        date_input: A string (returned as-is), a ``datetime.date``, or a
-            ``datetime.datetime`` object.
+        date_input: A ``YYYY-MM-DD`` string, a ``datetime.date``, or a
+            ``datetime.datetime`` object. Datetime values are reduced to
+            their calendar date.
 
     Returns:
         An ISO-8601 date string, e.g. ``"2024-01-15"``.
 
     Raises:
-        ValueError: If *date_input* is not one of the supported types.
+        ValueError: If *date_input* is not a supported type, is not exactly
+            ``YYYY-MM-DD``, or is not a real calendar date.
     """
     if isinstance(date_input, str):
+        if not _ISO_DATE_PATTERN.fullmatch(date_input):
+            raise ValueError("Date strings must use YYYY-MM-DD format")
+        try:
+            date.fromisoformat(date_input)
+        except ValueError:
+            raise ValueError(
+                "Date strings must use YYYY-MM-DD format and contain a valid calendar date"
+            )
         return date_input
     elif isinstance(date_input, datetime):
         return date_input.date().isoformat()
     elif isinstance(date_input, date):
         return date_input.isoformat()
     else:
-        raise ValueError(f"Invalid date type: {type(date_input)}")
+        raise ValueError(
+            "Invalid date type; dates must be YYYY-MM-DD strings, "
+            "datetime.date, or datetime.datetime values"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Commodity catalog search
+# ---------------------------------------------------------------------------
+
+_SEARCH_FIELDS = (
+    "code",
+    "name",
+    "category",
+    "description",
+    "currency",
+    "unit",
+    "source",
+)
+_SEARCH_SEPARATOR_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def _normalize_search_text(value: Any) -> str:
+    return _SEARCH_SEPARATOR_PATTERN.sub(" ", str(value).lower()).strip()
+
+
+def extract_commodity_catalog(value: Any) -> List[Dict[str, Any]]:
+    """Normalize direct and nested API catalog response shapes to a list."""
+    if isinstance(value, list):
+        return [dict(item) for item in value if isinstance(item, Mapping)]
+    if isinstance(value, Mapping):
+        if "commodities" in value:
+            return extract_commodity_catalog(value["commodities"])
+        if "data" in value:
+            return extract_commodity_catalog(value["data"])
+    return []
+
+
+def search_commodity_catalog(
+    catalog: Iterable[Mapping[str, Any]],
+    query: str,
+    limit: int = 10,
+) -> List[Dict[str, Any]]:
+    """Search a freshly fetched commodity catalog without a frozen code list.
+
+    Results are ranked by exact/prefix code matches, whole-query matches, then
+    token coverage across code, name, category, description, currency, unit,
+    and source. Non-mapping catalog entries are ignored.
+    """
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("Commodity search query must be a non-empty string")
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 100:
+        raise ValueError("Commodity search limit must be an integer from 1 to 100")
+
+    normalized_query = _normalize_search_text(query)
+    query_tokens = normalized_query.split()
+    ranked = []
+
+    for index, item in enumerate(catalog):
+        if not isinstance(item, Mapping):
+            continue
+
+        normalized_fields = {
+            field: _normalize_search_text(item.get(field, ""))
+            for field in _SEARCH_FIELDS
+        }
+        code = normalized_fields["code"]
+        searchable = " ".join(value for value in normalized_fields.values() if value)
+        token_hits = sum(token in searchable for token in query_tokens)
+        if normalized_query not in searchable and token_hits == 0:
+            continue
+
+        score = token_hits * 100
+        if normalized_query == code:
+            score += 10_000
+        elif code.startswith(normalized_query):
+            score += 5_000
+        elif normalized_query in code:
+            score += 3_000
+        if normalized_query == normalized_fields["name"]:
+            score += 2_000
+        elif normalized_query in normalized_fields["name"]:
+            score += 1_000
+
+        ranked.append(
+            (
+                -score,
+                str(item.get("code", "")),
+                index,
+                dict(item),
+            )
+        )
+
+    ranked.sort(key=lambda result: result[:3])
+    return [result[3] for result in ranked[:limit]]
 
 
 # ---------------------------------------------------------------------------

--- a/oilpriceapi/resources/bunker_fuels.py
+++ b/oilpriceapi/resources/bunker_fuels.py
@@ -7,6 +7,8 @@ Marine bunker fuel price operations.
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ..resource_validators import format_date
+
 
 class BunkerFuelsResource:
     """Resource for marine bunker fuel prices."""
@@ -147,9 +149,9 @@ class BunkerFuelsResource:
             "port": port,
             "fuel_type": fuel_type
         }
-        if start_date:
+        if start_date is not None:
             params["start_date"] = self._format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = self._format_date(end_date)
 
         response = self.client.request(
@@ -196,11 +198,4 @@ class BunkerFuelsResource:
 
     def _format_date(self, date_input: Union[str, date, datetime]) -> str:
         """Format date for API."""
-        if isinstance(date_input, str):
-            return date_input
-        elif isinstance(date_input, datetime):
-            return date_input.date().isoformat()
-        elif isinstance(date_input, date):
-            return date_input.isoformat()
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return format_date(date_input)

--- a/oilpriceapi/resources/commodities.py
+++ b/oilpriceapi/resources/commodities.py
@@ -6,6 +6,8 @@ Commodity catalog and category operations.
 
 from typing import Any, Dict, List
 
+from ..resource_validators import extract_commodity_catalog, search_commodity_catalog
+
 
 class CommoditiesResource:
     """Resource for commodity catalog operations."""
@@ -34,10 +36,7 @@ class CommoditiesResource:
             path="/v1/commodities"
         )
 
-        # Parse response
-        if "data" in response:
-            return response["data"]
-        return response
+        return extract_commodity_catalog(response)
 
     def get(self, code: str) -> Dict[str, Any]:
         """Get details for a single commodity.
@@ -63,6 +62,28 @@ class CommoditiesResource:
         if "data" in response:
             return response["data"]
         return response
+
+    def search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Search the API's current commodity catalog.
+
+        The catalog is fetched on every call so results do not depend on a
+        stale code list bundled with the SDK. Network and API errors retain
+        their normal typed exceptions.
+
+        Args:
+            query: Words from a code, name, category, description, currency,
+                unit, or source.
+            limit: Maximum results, from 1 to 100.
+
+        Returns:
+            Ranked commodity objects, or an empty list when nothing matches.
+
+        Example:
+            >>> matches = client.commodities.search("brent crude")
+            >>> for item in matches:
+            ...     print(item["code"])
+        """
+        return search_commodity_catalog(self.list(), query=query, limit=limit)
 
     def categories(self) -> Dict[str, List[Dict[str, Any]]]:
         """Get commodities grouped by category.

--- a/oilpriceapi/resources/futures.py
+++ b/oilpriceapi/resources/futures.py
@@ -18,6 +18,7 @@ Valid slugs: ``ice-brent``, ``ice-wti``, ``ice-gasoil``, ``natural-gas``,
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ..resource_validators import format_date
 from ._futures_slug import normalize_futures_slug
 
 
@@ -86,9 +87,9 @@ class FuturesResource:
         """
         slug = normalize_futures_slug(contract)
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = self._format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = self._format_date(end_date)
 
         response = self.client.request(
@@ -121,8 +122,8 @@ class FuturesResource:
         """
         slug = normalize_futures_slug(contract)
         params = {}
-        if date:
-            params["date"] = date
+        if date is not None:
+            params["date"] = format_date(date)
 
         response = self.client.request(
             method="GET",
@@ -262,11 +263,4 @@ class FuturesResource:
 
     def _format_date(self, date_input: Union[str, date, datetime]) -> str:
         """Format date for API."""
-        if isinstance(date_input, str):
-            return date_input
-        elif isinstance(date_input, datetime):
-            return date_input.date().isoformat()
-        elif isinstance(date_input, date):
-            return date_input.isoformat()
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return format_date(date_input)

--- a/oilpriceapi/resources/historical.py
+++ b/oilpriceapi/resources/historical.py
@@ -9,6 +9,7 @@ from typing import Generator, List, Optional, Set, Tuple, Union
 
 from .._pagination import validate_page_size
 from ..models import HistoricalPrice, HistoricalResponse, PaginationMeta
+from ..resource_validators import format_date
 
 DEFAULT_AUTO_PAGE_SIZE = 500
 HISTORICAL_DATAFRAME_COLUMNS = [
@@ -41,14 +42,7 @@ class HistoricalResource:
 
     def _parse_date(self, date_input: Union[str, date, datetime]) -> date:
         """Parse date input to date object."""
-        if isinstance(date_input, str):
-            return datetime.fromisoformat(date_input).date()
-        elif isinstance(date_input, datetime):
-            return date_input.date()
-        elif isinstance(date_input, date):
-            return date_input
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return date.fromisoformat(format_date(date_input))
 
     def _get_optimal_endpoint(
         self,
@@ -181,16 +175,20 @@ class HistoricalResource:
         }
 
         # Add date parameters if provided
-        if start_date:
-            params["start_date"] = self._format_date(start_date)
-        if end_date:
-            params["end_date"] = self._format_date(end_date)
+        normalized_start = (
+            self._format_date(start_date) if start_date is not None else None
+        )
+        normalized_end = self._format_date(end_date) if end_date is not None else None
+        if normalized_start is not None:
+            params["start_date"] = normalized_start
+        if normalized_end is not None:
+            params["end_date"] = normalized_end
 
         # Select optimal endpoint based on date range
-        endpoint = self._get_optimal_endpoint(start_date, end_date)
+        endpoint = self._get_optimal_endpoint(normalized_start, normalized_end)
 
         # Calculate appropriate timeout
-        request_timeout = self._calculate_timeout(start_date, end_date, timeout)
+        request_timeout = self._calculate_timeout(normalized_start, normalized_end, timeout)
 
         # Make request with optimal endpoint and timeout — use request_with_headers
         # so we can read X-Has-Next for reliable pagination detection
@@ -445,11 +443,4 @@ class HistoricalResource:
 
     def _format_date(self, date_input: Union[str, date, datetime]) -> str:
         """Format date for API."""
-        if isinstance(date_input, str):
-            return date_input
-        elif isinstance(date_input, datetime):
-            return date_input.date().isoformat()
-        elif isinstance(date_input, date):
-            return date_input.isoformat()
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return format_date(date_input)

--- a/oilpriceapi/resources/rig_counts.py
+++ b/oilpriceapi/resources/rig_counts.py
@@ -7,6 +7,8 @@ Oil and gas drilling rig count operations.
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ..resource_validators import format_date
+
 
 class RigCountsResource:
     """Resource for drilling rig count data."""
@@ -86,9 +88,9 @@ class RigCountsResource:
             ...     print(f"{record['date']}: {record['total']} rigs")
         """
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = self._format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = self._format_date(end_date)
 
         response = self.client.request(
@@ -152,11 +154,4 @@ class RigCountsResource:
 
     def _format_date(self, date_input: Union[str, date, datetime]) -> str:
         """Format date for API."""
-        if isinstance(date_input, str):
-            return date_input
-        elif isinstance(date_input, datetime):
-            return date_input.date().isoformat()
-        elif isinstance(date_input, date):
-            return date_input.isoformat()
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return format_date(date_input)

--- a/oilpriceapi/resources/storage.py
+++ b/oilpriceapi/resources/storage.py
@@ -7,6 +7,8 @@ Oil inventory and storage data operations.
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+from ..resource_validators import format_date
+
 
 class StorageResource:
     """Resource for oil storage and inventory data."""
@@ -140,9 +142,9 @@ class StorageResource:
             ...     print(f"{record['date']}: {record['value']} barrels")
         """
         params = {}
-        if start_date:
+        if start_date is not None:
             params["start_date"] = self._format_date(start_date)
-        if end_date:
+        if end_date is not None:
             params["end_date"] = self._format_date(end_date)
 
         response = self.client.request(
@@ -158,11 +160,4 @@ class StorageResource:
 
     def _format_date(self, date_input: Union[str, date, datetime]) -> str:
         """Format date for API."""
-        if isinstance(date_input, str):
-            return date_input
-        elif isinstance(date_input, datetime):
-            return date_input.date().isoformat()
-        elif isinstance(date_input, date):
-            return date_input.isoformat()
-        else:
-            raise ValueError(f"Invalid date type: {type(date_input)}")
+        return format_date(date_input)

--- a/oilpriceapi/resources/well_production.py
+++ b/oilpriceapi/resources/well_production.py
@@ -17,7 +17,7 @@ the Drilling Intelligence feature; other plans receive a 403
 
 from typing import Any, Dict, Optional, cast
 
-from ..resource_validators import normalize_api_number
+from ..resource_validators import format_date, normalize_api_number
 
 
 class WellProductionResource:
@@ -114,9 +114,9 @@ class WellProductionResource:
             ...     print(f"{month['period']}: {month['oil_bbl']} bbl")
         """
         if start_date is not None:
-            params["start_date"] = start_date
+            params["start_date"] = format_date(start_date)
         if end_date is not None:
-            params["end_date"] = end_date
+            params["end_date"] = format_date(end_date)
         response = self.client.request(
             method="GET",
             path=f"/v1/well-production/states/{code}",
@@ -236,8 +236,8 @@ class WellProductionResource:
         """
         filters: Dict[str, Any] = {
             "state": state,
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": format_date(start_date) if start_date is not None else None,
+            "end_date": format_date(end_date) if end_date is not None else None,
             "operator": operator,
             "formation": formation,
             "lat": lat,
@@ -290,8 +290,8 @@ class WellProductionResource:
         """
         filters: Dict[str, Any] = {
             "state": state,
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": format_date(start_date) if start_date is not None else None,
+            "end_date": format_date(end_date) if end_date is not None else None,
             "lat": lat,
             "lng": lng,
             "radius_miles": radius_miles,

--- a/tests/unit/test_commodities_resource.py
+++ b/tests/unit/test_commodities_resource.py
@@ -2,8 +2,10 @@
 Unit tests for CommoditiesResource
 """
 
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import Mock, patch
+
 from oilpriceapi import OilPriceAPI
 
 
@@ -58,6 +60,20 @@ class TestCommoditiesResource:
 
             assert len(commodities) == 1
             assert commodities[0]["code"] == "BRENT_CRUDE_USD"
+
+    def test_list_commodities_current_nested_response(self, client, mock_commodity):
+        """Test the production data.commodities response envelope."""
+        response = {
+            "data": {
+                "commodities": [mock_commodity],
+                "metadata": {"total": 1},
+            }
+        }
+
+        with patch.object(client, "request", return_value=response):
+            commodities = client.commodities.list()
+
+        assert commodities == [mock_commodity]
 
     def test_get_commodity(self, client, mock_commodity):
         """Test getting a specific commodity"""

--- a/tests/unit/test_date_and_commodity_guidance.py
+++ b/tests/unit/test_date_and_commodity_guidance.py
@@ -1,0 +1,186 @@
+"""Regression tests for date validation and live commodity-code guidance."""
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from oilpriceapi import AsyncOilPriceAPI, OilPriceAPI
+from oilpriceapi.exceptions import BadRequestError, NetworkError, error_from_response
+from oilpriceapi.resource_validators import format_date
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2025-03-010",
+        "2025-3-01",
+        "2025-02-29",
+        "2025-03-01T12:00:00",
+        "",
+    ],
+)
+def test_format_date_rejects_malformed_or_non_date_strings(value):
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        format_date(value)
+
+
+def test_format_date_accepts_strict_strings_and_python_date_types():
+    assert format_date("2024-02-29") == "2024-02-29"
+    assert format_date(date(2024, 2, 29)) == "2024-02-29"
+    assert format_date(datetime(2024, 2, 29, 23, 59)) == "2024-02-29"
+
+
+def test_malformed_historical_date_fails_without_request():
+    client = OilPriceAPI(api_key="test-key")
+    with patch.object(client, "request_with_headers") as request:
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            client.historical.get("BRENT_CRUDE_USD", start_date="2025-03-010")
+    request.assert_not_called()
+    client.close()
+
+
+def test_well_formed_reversed_range_is_left_to_server():
+    client = OilPriceAPI(api_key="test-key")
+    response = {"status": "success", "data": {"prices": []}}
+    with patch.object(
+        client,
+        "request_with_headers",
+        return_value=(response, {}),
+    ) as request:
+        client.historical.get(
+            "BRENT_CRUDE_USD",
+            start_date="2025-03-02",
+            end_date="2025-03-01",
+        )
+    request.assert_called_once()
+    assert request.call_args.kwargs["params"]["start_date"] == "2025-03-02"
+    assert request.call_args.kwargs["params"]["end_date"] == "2025-03-01"
+    client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_malformed_historical_date_fails_without_request():
+    client = AsyncOilPriceAPI(api_key="test-key")
+    client.request = AsyncMock()
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        await client.historical.get(
+            "BRENT_CRUDE_USD",
+            start_date="2025-03-010",
+        )
+    client.request.assert_not_awaited()
+    await client.close()
+
+
+def test_commodities_search_uses_current_catalog_and_ranks_code_matches():
+    client = OilPriceAPI(api_key="test-key")
+    catalog = [
+        {
+            "code": "WTI_USD",
+            "name": "WTI Crude Oil",
+            "category": "Crude Oil",
+        },
+        {
+            "code": "BRENT_CRUDE_USD",
+            "name": "Brent Crude Oil",
+            "category": "Crude Oil",
+        },
+        {
+            "code": "BRENT_CRUDE_EUR",
+            "name": "Brent Crude Oil",
+            "category": "Crude Oil",
+        },
+    ]
+    with patch.object(
+        client,
+        "request",
+        return_value={"data": {"commodities": catalog, "metadata": {"count": 3}}},
+    ) as request:
+        matches = client.commodities.search("brent crude usd", limit=2)
+    request.assert_called_once_with(method="GET", path="/v1/commodities")
+    assert [item["code"] for item in matches] == [
+        "BRENT_CRUDE_USD",
+        "BRENT_CRUDE_EUR",
+    ]
+    client.close()
+
+
+def test_commodities_search_returns_empty_list_for_empty_catalog():
+    client = OilPriceAPI(api_key="test-key")
+    with patch.object(client, "request", return_value={"data": []}):
+        assert client.commodities.search("brent") == []
+    client.close()
+
+
+def test_commodities_search_preserves_network_error():
+    client = OilPriceAPI(api_key="test-key")
+    network_error = NetworkError("catalog unavailable")
+    with patch.object(client, "request", side_effect=network_error):
+        with pytest.raises(NetworkError) as raised:
+            client.commodities.search("brent")
+    assert raised.value is network_error
+    client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_commodities_search_matches_sync_behavior():
+    client = AsyncOilPriceAPI(api_key="test-key")
+    client.request = AsyncMock(
+        return_value={
+            "data": [
+                {"code": "WTI_USD", "name": "WTI Crude Oil"},
+                {"code": "BRENT_CRUDE_USD", "name": "Brent Crude Oil"},
+            ]
+        }
+    )
+    matches = await client.commodities.search("brent")
+    assert [item["code"] for item in matches] == ["BRENT_CRUDE_USD"]
+    await client.close()
+
+
+def test_nested_invalid_code_response_exposes_sanitized_suggestions():
+    secret = "secret-test-key"
+    response = httpx.Response(
+        400,
+        request=httpx.Request(
+            "GET",
+            "https://api.oilpriceapi.com/v1/prices/latest",
+            headers={"Authorization": f"Token {secret}"},
+        ),
+        json={
+            "status": "fail",
+            "data": {
+                "error": "invalid_code",
+                "message": f"Unknown code; credential {secret}",
+                "suggestions": [
+                    "BRENT_CRUDE_USD",
+                    secret,
+                    {"unexpected": "shape"},
+                ],
+                "invalid_codes": ["BRENNT"],
+            },
+        },
+    )
+
+    error = error_from_response(response, commodity="BRENNT")
+
+    assert isinstance(error, BadRequestError)
+    assert error.code == "invalid_code"
+    assert error.suggestions == ["BRENT_CRUDE_USD", "[REDACTED]"]
+    assert error.invalid_codes == ["BRENNT"]
+    assert secret not in error.message
+    assert secret not in repr(error.suggestions)
+
+
+def test_legacy_top_level_error_message_is_not_misclassified_as_a_code():
+    response = httpx.Response(
+        400,
+        request=httpx.Request("GET", "https://api.oilpriceapi.com/v1/prices/latest"),
+        json={"error": "Invalid request parameters"},
+    )
+
+    error = error_from_response(response)
+
+    assert error.message == "Invalid request parameters"
+    assert error.code is None


### PR DESCRIPTION
Closes #71.

## What changed
- reject malformed or impossible `YYYY-MM-DD` values locally across sync/async date-bearing resources
- preserve server authority for well-formed range semantics
- add sync/async `commodities.search()` backed by the current API catalog
- normalize the production `data.commodities` catalog envelope
- expose bounded, credential-redacted `suggestions` and `invalid_codes` from fail/data errors
- document date validation, current-catalog discovery, and typed recovery without customer evidence

## Verification
- 416 non-integration/non-contract tests pass; 65.54% coverage
- 15 new date/code-guidance tests plus nested catalog regression
- Ruff clean for source and changed tests
- targeted mypy clean with optional imports skipped
- sdist and wheel build successfully
- MkDocs build, storefront claims, secret guard, and `git diff --check` pass
- read-only production smoke: 425 catalog entries; search returns current Brent codes; invalid-code response exposes typed suggestions

## Deployment safety
This PR does not publish a package or trigger either core frontend/backend deployment. The repository GitHub Pages workflow is the only authorized deployment path after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous commodity-code catalog search with ranked results.
  * Invalid-code errors now include sanitized suggestions and invalid codes when available.
* **Bug Fixes**
  * Date inputs are consistently normalized across historical and resource requests.
  * Malformed or impossible `YYYY-MM-DD` dates are rejected before requests are sent.
* **Documentation**
  * Added guidance for date validation, commodity searches, error recovery, and historical data usage.
  * Updated navigation and examples to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->